### PR TITLE
chore: Update fluent-bit config (#108)

### DIFF
--- a/add-ons/fluent-bit/README.md
+++ b/add-ons/fluent-bit/README.md
@@ -4,6 +4,36 @@
 
 A Helm chart for Fluent Bit
 
+## Fluentbit Events
+
+This chart integrates Fluent Bit as a log processor and forwarder, specifically configured to capture Kubernetes and CloudEvents from Tekton.
+It relies on the KubeRocketCI's OpenSearch chart for log storage and analysis, providing a cohesive logging solution.
+
++--------+       +-------------+       +------------+       +-----------+
+| Tekton +------>+ CloudEvents +------>+ Fluent Bit +------>+ OpenSearch|
++--------+       +-------------+       +------------+       +-----------+
+                                             |
+                                             |
+                                        +----+----+
+                                        | k8s     |
+                                        | Events  |
+                                        +---------+
+
+### Key Features and Configurations:
+
+- **Deployment Mode**: Fluent Bit is deployed as a single instance to efficiently gather events across the cluster.
+- **CloudEvents Support**: Custom port configuration (8888) to receive CloudEvents from Tekton Pipelines.
+- **RBAC and Access**: Automatically creates RBAC resources with access to Kubernetes events.
+- **Elasticsearch Integration**: Environment variables are configured to use credentials from a secret for Elasticsearch access.
+- **Monitoring**: A ServiceMonitor is configured for Prometheus scraping, with detailed metric and relabeling configurations.
+
+### Inputs and Outputs:
+
+- **Inputs**: Captures Kubernetes events and HTTP CloudEvents.
+- **Outputs**: Configured to forward logs to an OpenSearch cluster with specific formatting and TLS settings.
+
+For further customization and to tailor the Fluent Bit configuration to your needs, please review the `values.yaml` file.
+
 ## Requirements
 
 | Repository | Name | Version |
@@ -19,13 +49,52 @@ A Helm chart for Fluent Bit
 | eso.secretName | string | `"/edp/eks/addons/fluent-bit"` | Value name in AWS ParameterStore, AWS SecretsManager or other Secret Store. |
 | eso.secretStoreName | string | `"aws-parameterstore"` | Defines Secret Store name. |
 | eso.type | string | `"aws"` | Defines provider type. One of `aws` or `generic`. |
-| fluent-bit.config.customParsers | string | `"[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n\n[PARSER]\n    Name        java_multiline\n    Format      regex\n    Regex       /^(?<time>\\d{4}-\\d{1,2}-\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}) (?<level>[^\\s]+)(?<message>.*)/\n    Time_Key    time\n    Time_Format %Y-%m-%d %H:%M:%S\n"` |  |
-| fluent-bit.config.outputs | string | `"[OUTPUT]\n    Name            es\n    Match           kube.*\n    Host            opensearch-cluster-master\n    Port            9200\n    HTTP_User       ${ES_SUPERUSER_USER}\n    HTTP_Passwd     ${ES_SUPERUSER_PASSWORD}\n    Logstash_Format On\n    Logstash_Prefix kube-fluent-bit\n    Time_Key        @timestamp\n    Replace_Dots    On\n    Retry_Limit     False\n    Trace_Error     Off\n    Suppress_Type_Name On\n    tls             On\n    tls.verify      Off\n"` |  |
+| fluent-bit.config.inputs | string | `"[INPUT]\n    Name kubernetes_events\n    # add the tag \"k8s_events\" to all events coming from this input\n    tag k8s_events\n    # ask k8s API for updates every 30 seconds\n    interval_sec 15\n    # fetch at most 250 items per requests (pagination)\n    kube_request_limit 2500\n\n# Use as the synk for the CloudEvents from Tekton Pipelines\n[INPUT]\n    name http\n    listen 0.0.0.0\n    port 8888\n"` |  |
+| fluent-bit.config.outputs | string | `"[OUTPUT]\n    Name            es\n    Match           k8s_events\n    Host            opensearch-cluster-master\n    Port            9200\n    HTTP_User       ${ES_SUPERUSER_USER}\n    HTTP_Passwd     ${ES_SUPERUSER_PASSWORD}\n    Logstash_Format On\n    Logstash_Prefix logstash-events\n    Time_Key        @timestamp\n    Replace_Dots    On\n    Retry_Limit     False\n    Trace_Error     Off\n    Suppress_Type_Name On\n    tls             On\n    tls.verify      Off\n\n[OUTPUT]\n    Name            es\n    Match           http.0\n    Host            opensearch-cluster-master\n    Port            9200\n    HTTP_User       ${ES_SUPERUSER_USER}\n    HTTP_Passwd     ${ES_SUPERUSER_PASSWORD}\n    Logstash_Format On\n    Logstash_Prefix logstash-cloudevents\n    Time_Key        @timestamp\n    Replace_Dots    On\n    Retry_Limit     False\n    Trace_Error     Off\n    Suppress_Type_Name On\n    tls             On\n    tls.verify      Off\n"` |  |
 | fluent-bit.env[0].name | string | `"ES_SUPERUSER_USER"` |  |
 | fluent-bit.env[0].valueFrom.secretKeyRef.key | string | `"username"` |  |
 | fluent-bit.env[0].valueFrom.secretKeyRef.name | string | `"fluentbit-creds"` |  |
 | fluent-bit.env[1].name | string | `"ES_SUPERUSER_PASSWORD"` |  |
 | fluent-bit.env[1].valueFrom.secretKeyRef.key | string | `"password"` |  |
 | fluent-bit.env[1].valueFrom.secretKeyRef.name | string | `"fluentbit-creds"` |  |
+| fluent-bit.extraPorts[0].containerPort | int | `8888` |  |
+| fluent-bit.extraPorts[0].name | string | `"cloudevents"` |  |
+| fluent-bit.extraPorts[0].port | int | `8888` |  |
+| fluent-bit.extraPorts[0].protocol | string | `"TCP"` |  |
+| fluent-bit.kind | string | `"Deployment"` |  |
+| fluent-bit.rbac.create | bool | `true` |  |
+| fluent-bit.rbac.eventsAccess | bool | `true` |  |
+| fluent-bit.resources.limits.memory | string | `"128Mi"` |  |
+| fluent-bit.resources.requests.cpu | string | `"100m"` |  |
+| fluent-bit.resources.requests.memory | string | `"128Mi"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].interval | string | `"10s"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].metricRelabelings[0].action | string | `"replace"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].metricRelabelings[0].regex | string | `"(.*)"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].metricRelabelings[0].replacement | string | `"${1}"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].metricRelabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_service_label_cluster"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].metricRelabelings[0].targetLabel | string | `"cluster"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].path | string | `"/metrics"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].port | string | `"metrics"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].action | string | `"replace"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].regex | string | `"^(.*)$"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].replacement | string | `"$1"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].separator | string | `";"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_pod_node_name"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].relabelings[0].targetLabel | string | `"nodename"` |  |
+| fluent-bit.serviceMonitor.additionalEndpoints[0].scrapeTimeout | string | `"10s"` |  |
+| fluent-bit.serviceMonitor.enabled | bool | `true` |  |
+| fluent-bit.serviceMonitor.interval | string | `"10s"` |  |
+| fluent-bit.serviceMonitor.metricRelabelings[0].action | string | `"replace"` |  |
+| fluent-bit.serviceMonitor.metricRelabelings[0].regex | string | `"(.*)"` |  |
+| fluent-bit.serviceMonitor.metricRelabelings[0].replacement | string | `"${1}"` |  |
+| fluent-bit.serviceMonitor.metricRelabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_service_label_cluster"` |  |
+| fluent-bit.serviceMonitor.metricRelabelings[0].targetLabel | string | `"cluster"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].action | string | `"replace"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].regex | string | `"^(.*)$"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].replacement | string | `"$1"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].separator | string | `";"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_pod_node_name"` |  |
+| fluent-bit.serviceMonitor.relabelings[0].targetLabel | string | `"nodename"` |  |
+| fluent-bit.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| fluent-bit.serviceMonitor.selector.release | string | `"kube-prometheus"` |  |
 | fluent-bit.testFramework.enabled | bool | `false` |  |
-

--- a/add-ons/fluent-bit/README.md.gotmpl
+++ b/add-ons/fluent-bit/README.md.gotmpl
@@ -1,0 +1,46 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Fluentbit Events
+
+This chart integrates Fluent Bit as a log processor and forwarder, specifically configured to capture Kubernetes and CloudEvents from Tekton.
+It relies on the KubeRocketCI's OpenSearch chart for log storage and analysis, providing a cohesive logging solution.
+
++--------+       +-------------+       +------------+       +-----------+
+| Tekton +------>+ CloudEvents +------>+ Fluent Bit +------>+ OpenSearch|
++--------+       +-------------+       +------------+       +-----------+
+                                             |
+                                             |
+                                        +----+----+
+                                        | k8s     |
+                                        | Events  |
+                                        +---------+
+
+### Key Features and Configurations:
+
+- **Deployment Mode**: Fluent Bit is deployed as a single instance to efficiently gather events across the cluster.
+- **CloudEvents Support**: Custom port configuration (8888) to receive CloudEvents from Tekton Pipelines.
+- **RBAC and Access**: Automatically creates RBAC resources with access to Kubernetes events.
+- **Elasticsearch Integration**: Environment variables are configured to use credentials from a secret for Elasticsearch access.
+- **Monitoring**: A ServiceMonitor is configured for Prometheus scraping, with detailed metric and relabeling configurations.
+
+### Inputs and Outputs:
+
+- **Inputs**: Captures Kubernetes events and HTTP CloudEvents.
+- **Outputs**: Configured to forward logs to an OpenSearch cluster with specific formatting and TLS settings.
+
+For further customization and to tailor the Fluent Bit configuration to your needs, please review the `values.yaml` file.
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/add-ons/fluent-bit/values.yaml
+++ b/add-ons/fluent-bit/values.yaml
@@ -1,6 +1,21 @@
+# This chart depends on the KubeRocketCI's opensearch chart and the fluent-bit chart.
 fluent-bit:
+  # we run only one instane of fluentbit which grabs events from k8s and cloud events
+  kind: Deployment
   testFramework:
     enabled: false
+
+  extraPorts:
+    # This port is used to receive CloudEvents from Tekton Pipelines
+    - name: cloudevents
+      port: 8888
+      containerPort: 8888
+      protocol: TCP
+
+  rbac:
+    create: true
+    # Work with kubernetes_events input plugin
+    eventsAccess: true
   env:
     - name: ES_SUPERUSER_USER
       valueFrom:
@@ -12,32 +27,101 @@ fluent-bit:
         secretKeyRef:
           name: fluentbit-creds
           key: password
-  config:
-    customParsers: |
-      [PARSER]
-          Name docker_no_time
-          Format json
-          Time_Keep Off
-          Time_Key time
-          Time_Format %Y-%m-%dT%H:%M:%S.%L
 
-      [PARSER]
-          Name        java_multiline
-          Format      regex
-          Regex       /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<level>[^\s]+)(?<message>.*)/
-          Time_Key    time
-          Time_Format %Y-%m-%d %H:%M:%S
+  serviceMonitor:
+    enabled: true
+    interval: 10s
+    scrapeTimeout: 10s
+    selector:
+      release: kube-prometheus
+    metricRelabelings:
+      - sourceLabels: [__meta_kubernetes_service_label_cluster]
+        targetLabel: cluster
+        regex: (.*)
+        replacement: ${1}
+        action: replace
+    relabelings:
+      - sourceLabels: [__meta_kubernetes_pod_node_name]
+        separator: ;
+        regex: ^(.*)$
+        targetLabel: nodename
+        replacement: $1
+        action: replace
+
+    additionalEndpoints:
+      - port: metrics
+        path: /metrics
+        interval: 10s
+        scrapeTimeout: 10s
+        # metric relabel configs to apply to samples before ingestion.
+        #
+        metricRelabelings:
+          - sourceLabels: [__meta_kubernetes_service_label_cluster]
+            targetLabel: cluster
+            regex: (.*)
+            replacement: ${1}
+            action: replace
+        # relabel configs to apply to samples after ingestion.
+        #
+        relabelings:
+          - sourceLabels: [__meta_kubernetes_pod_node_name]
+            separator: ;
+            regex: ^(.*)$
+            targetLabel: nodename
+            replacement: $1
+            action: replace
+
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  config:
+    inputs: |
+      [INPUT]
+          Name kubernetes_events
+          # add the tag "k8s_events" to all events coming from this input
+          tag k8s_events
+          # ask k8s API for updates every 30 seconds
+          interval_sec 15
+          # fetch at most 250 items per requests (pagination)
+          kube_request_limit 2500
+
+      # Use as the synk for the CloudEvents from Tekton Pipelines
+      [INPUT]
+          name http
+          listen 0.0.0.0
+          port 8888
 
     outputs: |
       [OUTPUT]
           Name            es
-          Match           kube.*
+          Match           k8s_events
           Host            opensearch-cluster-master
           Port            9200
           HTTP_User       ${ES_SUPERUSER_USER}
           HTTP_Passwd     ${ES_SUPERUSER_PASSWORD}
           Logstash_Format On
-          Logstash_Prefix kube-fluent-bit
+          Logstash_Prefix logstash-events
+          Time_Key        @timestamp
+          Replace_Dots    On
+          Retry_Limit     False
+          Trace_Error     Off
+          Suppress_Type_Name On
+          tls             On
+          tls.verify      Off
+
+      [OUTPUT]
+          Name            es
+          Match           http.0
+          Host            opensearch-cluster-master
+          Port            9200
+          HTTP_User       ${ES_SUPERUSER_USER}
+          HTTP_Passwd     ${ES_SUPERUSER_PASSWORD}
+          Logstash_Format On
+          Logstash_Prefix logstash-cloudevents
           Time_Key        @timestamp
           Replace_Dots    On
           Retry_Limit     False


### PR DESCRIPTION
This commit modifies the fluent-bit configuration to include an additional port (8888) for receiving CloudEvents from Tekton Pipelines. This allows fluent-bit to capture both Kubernetes events and CloudEvents, providing a more comprehensive logging solution. The configuration also includes the necessary inputs and outputs for forwarding the logs to an OpenSearch cluster with specific formatting and TLS settings.

Fixes #108 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits
