### PR TITLE
chore: Bump PGO version from 5.4.3 to 5.7.0(#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ make update-readme
 | oauth2-proxy           | 7.6.0     | v7.6.0       | False             | False    |
 | opensearch             | 2.21.1    | 2.15.0       | False             | False    |
 | opentelemetry-operator | 0.62.0    | 0.102.0      | False             | False    |
-| postgres-operator      | 0.1.0     | 5.4.3        | False             | False    |
+| postgres-operator      | 0.1.0     | 5.7.0        | False             | False    |
 | report-portal          | 5.10.0    | 23.2         | False             | False    |
 | prometheus-operator    | 61.3.2    | v0.75.1      | False             | False    |
 | redis-operator         | 0.1.0     | 3.2.8        | False             | False    |

--- a/add-ons/postgres-operator/Chart.yaml
+++ b/add-ons/postgres-operator/Chart.yaml
@@ -12,9 +12,9 @@ version: 0.1.0
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "5.4.3"
+appVersion: "5.7.0"
 
 dependencies:
 - name: pgo
-  version: "5.4.3"
+  version: "5.7.0"
   repository: oci://registry.developers.crunchydata.com/crunchydata

--- a/add-ons/postgres-operator/README.md
+++ b/add-ons/postgres-operator/README.md
@@ -1,6 +1,6 @@
 # postgres-operator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.3](https://img.shields.io/badge/AppVersion-5.4.3-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for Postgres Operator
 
@@ -8,30 +8,28 @@ A Helm chart for Postgres Operator
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry.developers.crunchydata.com/crunchydata | pgo | 5.4.3 |
+| oci://registry.developers.crunchydata.com/crunchydata | pgo | 5.7.0 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| pgo.controllerImages.cluster | string | `"registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.3.1-0"` |  |
-| pgo.controllerImages.upgrade | string | `"registry.developers.crunchydata.com/crunchydata/postgres-operator-upgrade:ubi8-5.3.1-0"` |  |
+| pgo.controllerImages.cluster | string | `"registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.7.0-0"` |  |
 | pgo.debug | bool | `false` |  |
 | pgo.imagePullSecretNames | list | `[]` |  |
-| pgo.relatedImages."postgres_13_gis_3.0".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.0-0"` |  |
-| pgo.relatedImages."postgres_13_gis_3.1".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.1-0"` |  |
-| pgo.relatedImages."postgres_14_gis_3.1".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.1-0"` |  |
-| pgo.relatedImages."postgres_14_gis_3.2".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.2-0"` |  |
-| pgo.relatedImages."postgres_14_gis_3.3".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.3-0"` |  |
-| pgo.relatedImages."postgres_15_gis_3.3".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.2-3.3-0"` |  |
-| pgo.relatedImages.pgadmin.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-10"` |  |
-| pgo.relatedImages.pgbackrest.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.41-4"` |  |
-| pgo.relatedImages.pgbouncer.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.18-0"` |  |
-| pgo.relatedImages.pgexporter.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.3.1-0"` |  |
-| pgo.relatedImages.pgupgrade.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.3.1-0"` |  |
-| pgo.relatedImages.postgres_13.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.10-0"` |  |
-| pgo.relatedImages.postgres_14.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0"` |  |
-| pgo.relatedImages.postgres_15.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.2-0"` |  |
+| pgo.relatedImages."postgres_15_gis_3.3".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.8-3.3-2"` |  |
+| pgo.relatedImages."postgres_16_gis_3.3".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.4-3.3-2"` |  |
+| pgo.relatedImages."postgres_16_gis_3.4".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.4-3.4-2"` |  |
+| pgo.relatedImages."postgres_17_gis_3.4".image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-17.0-3.4-0"` |  |
+| pgo.relatedImages.pgadmin.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-31"` |  |
+| pgo.relatedImages.pgbackrest.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.53.1-0"` |  |
+| pgo.relatedImages.pgbouncer.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.23-0"` |  |
+| pgo.relatedImages.pgexporter.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-0.15.0-12"` |  |
+| pgo.relatedImages.pgupgrade.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.7.0-0"` |  |
+| pgo.relatedImages.postgres_15.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.8-2"` |  |
+| pgo.relatedImages.postgres_16.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.4-2"` |  |
+| pgo.relatedImages.postgres_17.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-17.0-0"` |  |
+| pgo.relatedImages.standalone_pgadmin.image | string | `"registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-8.12-0"` |  |
 | pgo.resources.controller | object | `{}` |  |
 | pgo.resources.upgrade | object | `{}` |  |
 | pgo.singleNamespace | bool | `false` |  |

--- a/add-ons/postgres-operator/values.yaml
+++ b/add-ons/postgres-operator/values.yaml
@@ -1,39 +1,36 @@
 pgo:
   # controllerImages are used to run the PostgresCluster and PGUpgrade controllers.
   controllerImages:
-    cluster: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.3.1-0
-    upgrade: registry.developers.crunchydata.com/crunchydata/postgres-operator-upgrade:ubi8-5.3.1-0
+    cluster: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.7.0-0
 
-  # relatedImages are used when an image is omitted from PostgresCluster or PGUpgrade specs.
+  # relatedImages are used when an image is omitted from PostgresCluster, PGAdmin or PGUpgrade specs.
   relatedImages:
+    postgres_17:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-17.0-0
+    postgres_17_gis_3.4:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-17.0-3.4-0
+    postgres_16:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.4-2
+    postgres_16_gis_3.4:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.4-3.4-2
+    postgres_16_gis_3.3:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.4-3.3-2
     postgres_15:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.2-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.8-2
     postgres_15_gis_3.3:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.2-3.3-0
-    postgres_14:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0
-    postgres_14_gis_3.1:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.1-0
-    postgres_14_gis_3.2:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.2-0
-    postgres_14_gis_3.3:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.3-0
-    postgres_13:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.10-0
-    postgres_13_gis_3.0:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.0-0
-    postgres_13_gis_3.1:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.1-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.8-3.3-2
     pgadmin:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-10
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-31
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.41-4
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.53.1-0
     pgbouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.18-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.23-0
     pgexporter:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.3.1-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-0.15.0-12
     pgupgrade:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.3.1-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.7.0-0
+    standalone_pgadmin:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-8.12-0
 
   # singleNamespace controls where PGO watches for PostgresClusters. When false,
   # PGO watches for and responds to PostgresClusters in all namespaces. When true,


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Our applications, including Sonar, Harbor, and Report Portal, were deployed on a local Kind cluster using an older version of the Postgres Operator (v5.4.3). After upgrading to Postgres Operator v5.7.0, we verified that everything was functioning as expected. Following the upgrade, we disabled backups for these applications using annotations to ensure the changes were correctly applied and the system behaved as intended without impacting the overall functionality.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits
