### PR TITLE
chore: Bump defectdojo to 2.42.1 replace RabbitMQ with Redis(#213)

### DIFF
--- a/clusters/core/addons/defectdojo/Chart.yaml
+++ b/clusters/core/addons/defectdojo/Chart.yaml
@@ -6,13 +6,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.127
+version: 1.6.168
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.34.1
+appVersion: 2.42.1
 
 dependencies:
 - name: defectdojo
-  version: 1.6.127
+  version: 1.6.168
   repository: https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts

--- a/clusters/core/addons/defectdojo/README.md
+++ b/clusters/core/addons/defectdojo/README.md
@@ -1,6 +1,6 @@
 # defectdojo
 
-![Version: 1.6.127](https://img.shields.io/badge/Version-1.6.127-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.34.1](https://img.shields.io/badge/AppVersion-2.34.1-informational?style=flat-square)
+![Version: 1.6.168](https://img.shields.io/badge/Version-1.6.168-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.42.1](https://img.shields.io/badge/AppVersion-2.42.1-informational?style=flat-square)
 
 ## Secret management
 
@@ -16,9 +16,8 @@ kubectl create secret generic defectdojo-extrasecrets \
 ```
 
 ```bash
-kubectl create secret generic defectdojo-rabbitmq-specific \
-  --from-literal=rabbitmq-password=<rabbitmq-password>
-  --from-literal=rabbitmq-erlang-cookie=<rabbitmq-erlang-cookie>
+kubectl create secret generic defectdojo-redis-specific \
+  --from-literal=redis-password=<redis-password>
 ```
 
 ```bash
@@ -70,7 +69,7 @@ AWS Parameter Store structure:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts | defectdojo | 1.6.127 |
+| https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts | defectdojo | 1.6.168 |
 
 ## Values
 
@@ -98,9 +97,9 @@ AWS Parameter Store structure:
 | defectdojo.postgresql.auth.secretKeys.userPasswordKey | string | `"password"` |  |
 | defectdojo.postgresql.enabled | bool | `false` |  |
 | defectdojo.postgresql.postgresServer | string | `"defectdojo-primary.defectdojo.svc"` |  |
-| defectdojo.rabbitmq.persistence.size | string | `"1Gi"` |  |
+| defectdojo.redis.master.persistence.size | string | `"2Gi"` |  |
 | defectdojo.site_url | string | `"https://defectdojo.example.com"` |  |
-| defectdojo.tag | string | `"2.34.1"` |  |
+| defectdojo.tag | string | `"2.42.1"` |  |
 | eso.enabled | bool | `true` | Install components of the ESO. |
 | eso.generic.secretStore.providerConfig | object | `{}` | Defines SecretStore provider configuration. |
 | eso.roleArn | string | `"arn:aws:iam::012345678910:role/AWSIRSA_Shared_ExternalSecretOperatorAccess"` | Role ARN for the ExternalSecretOperator to assume. |

--- a/clusters/core/addons/defectdojo/README.md.gotmpl
+++ b/clusters/core/addons/defectdojo/README.md.gotmpl
@@ -21,9 +21,8 @@ kubectl create secret generic defectdojo-extrasecrets \
 ```
 
 ```bash
-kubectl create secret generic defectdojo-rabbitmq-specific \
-  --from-literal=rabbitmq-password=<rabbitmq-password>
-  --from-literal=rabbitmq-erlang-cookie=<rabbitmq-erlang-cookie>
+kubectl create secret generic defectdojo-redis-specific \
+  --from-literal=redis-password=<redis-password>
 ```
 
 ```bash

--- a/clusters/core/addons/defectdojo/templates/external-secrets/externalsecret-defectdojo-redis-specific.yaml
+++ b/clusters/core/addons/defectdojo/templates/external-secrets/externalsecret-defectdojo-redis-specific.yaml
@@ -3,19 +3,15 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: defectdojo-rabbitmq-specific
+  name: defectdojo-redis-specific
 spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: {{ .Values.eso.secretStoreName }}
   data:
-    - secretKey: rabbitmq-password
+    - secretKey: redis-password
       remoteRef:
         key: {{ $secretName }}
-        property: defectdojo.rabbitmq-password
-    - secretKey: rabbitmq-erlang-cookie
-      remoteRef:
-        key: {{ $secretName }}
-        property: defectdojo.rabbitmq-erlang-cookie
+        property: defectdojo.redis-password
 {{ end }}

--- a/clusters/core/addons/defectdojo/templates/postgresql.yaml
+++ b/clusters/core/addons/defectdojo/templates/postgresql.yaml
@@ -3,6 +3,7 @@ kind: PostgresCluster
 metadata:
   name: defectdojo
 spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0
   postgresVersion: 14
   port: 5432
   instances:
@@ -21,6 +22,7 @@ spec:
 
   backups:
     pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.41-4
       global:
         log-level-console: info
         log-level-file: info

--- a/clusters/core/addons/defectdojo/values.yaml
+++ b/clusters/core/addons/defectdojo/values.yaml
@@ -1,5 +1,5 @@
 defectdojo:
-  tag: 2.34.1
+  tag: 2.42.1
   fullnameOverride: defectdojo
   host: defectdojo.example.com
   site_url: https://defectdojo.example.com
@@ -31,9 +31,10 @@ defectdojo:
         adminPasswordKey: password
         userPasswordKey: password
 
-  rabbitmq:
-    persistence:
-      size: 1Gi
+  redis:
+    master:
+      persistence:
+        size: 2Gi
 
   # SSO Enablement. for additional options, please consult https://defectdojo.github.io/django-DefectDojo/integrations/social-authentication/#keycloak
   # Keycloak integration also requires DD_SOCIAL_AUTH_KEYCLOAK_SECRET to be defined, we recommend to create secret with name `defectdojo-extrasecrets`


### PR DESCRIPTION
# Pull Request Template

## Description
Bump defectdojo to 2.42.1
Align values: replace RabbitMQ with Redis
Remove RabbitMQ external secret
Add Redis external secret
Align README.md.gotmpl secret creation for Redis
Align Postgres operator configuration add default images

Fixes (https://github.com/epam/edp-cluster-add-ons/issues/213)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Deployed on test environment

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.