### PR TITLE
chore: Add readme how manage users in keycloak with krci rbac(#217)

### DIFF
--- a/clusters/core/addons/kuberocketci-rbac/README.md
+++ b/clusters/core/addons/kuberocketci-rbac/README.md
@@ -82,6 +82,128 @@ AWS Parameter Store structure:
 
 </details>
 
+<details>
+<summary><b>Examples 1: Users management without predefined broker realm:</b></summary>
+
+```
+broker:
+  # Create the broker realm with corresponding resources.
+  create: true
+  # If broker create parameter set to false operator create only a client for connection as Identity Provider,
+  # in this case be sure you define correct Realm name.
+  name: "broker"
+
+# Realm creating for connecting and managing shared services clients, such as Nexus, Sonar, DefectDojo, etc.
+sharedService: "shared"
+```
+
+Step-by-Step Guide to onboarding User:
+
+Step 1: Create a New User in the `broker` Realm:
+1. Go to the `broker` Realm.
+2. Select Users from the menu on the left and click Add User.
+3. Enter the following details:
+  * Username: A unique `username` (e.g., `developer123`).
+  * Email: The user's `email address` (e.g., `developer@example.com`).
+  * First Name: The user's `first name` (e.g., `John`).
+  * Last Name: The user's `last name` (e.g., `Doe`).
+4. Click Save to save the user's details.
+5. Go to the `Credentials` tab:
+  * Click `Set Password` button.
+  * Enter the new password twice.
+    Note: If the password is fixed, toggle the Temporary switch to Off.
+(Otherwise, the user will be prompted to change the password upon their first login).
+6. Go to the Details tab:
+   Copy the `User ID` and `Username`. These values will be required for the next step.
+
+Step 2: Link the User in the `shared` Realm
+1. Go to the `shared` Realm.
+2. Open `Users` tab and click `Add User` button.
+3. Set the Username to match the username in `broker` (e.g., `developer123`).
+4. Click Save to create the user.
+5. Open the newly created user, go to the `Identity Provider` Links tab:
+   Provide the following details from the `step 1.6`:
+   * User ID: The `ID` of user copied from the Details tab in the `broker` Realm.
+   * Username: The `Username` of user copied from the Details tab in the `broker` Realm.
+   * Click `Link` to complete the association.
+
+Step 3: Assign Groups to the User in the `shared` Realm
+  - Open the user in the `shared` Realm.
+  - Go to the `Groups` tab.
+  - Click `Join Group`.
+  - Select the `Developer` group and confirm the selection.
+
+Step 4: Assign Roles to the User in the `shared` Realm
+  - Go to the Role Mappings tab.
+  - In the Available Roles section, select the roles required for the user (e.g., `sonar-developers`).
+  - Click Assign to apply the roles.
+
+Result: The user will now be able to:
+
+- Access resources assigned to the `Developer` group.
+- Log in to SonarQube with the `sonar-developers` role.
+
+For more details on permissions and the platform's authentication model, refer to the documentation:
+[KuberocketCI Documentation — Platform Authentication Model](https://docs.kuberocketci.io/docs/operator-guide/auth/platform-auth-model/)
+
+</details>
+
+<details>
+<summary><b>Example 2: Users management with predefined broker realm:</b></summary>
+
+```
+broker:
+  # Create the broker realm with corresponding resources.
+  create: false
+  # If broker create parameter set to false operator create only a client for connection as Identity Provider,
+  # in this case be sure you define correct Realm name.
+
+existingBroker: "project-realm"
+
+sharedService: "shared"
+```
+
+Step-by-Step Guide to onboarding User:
+
+Step 1: Copy `username` and `ID` from existing `project-broker` Realm:
+1. Go to the `project-broker` Realm.
+2. Select `Users` tab.
+3. Enter the following details:
+4. Go to the Details tab:
+   Copy the `User ID` and `Username`. These values will be required for the next step.
+
+Step 2: Link the User in the `shared` Realm
+1. Go to the `shared` Realm.
+2. Open `Users` tab and click `Add User` button.
+3. Set the Username to match the `username` in `project-broker`.
+4. Click Save to create the user.
+5. Open the newly created user, go to the `Identity Provider` Links tab:
+   Provide the following details from the `step 1.4`:
+   * User ID: The `ID` of user copied from the Details tab in the `broker` Realm.
+   * Username: The `Username` of user copied from the Details tab in the `broker` Realm.
+   * Click `Link` to complete the association.
+
+Step 3: Assign Groups to the User in the `shared` Realm
+  - Open the user in the `shared` Realm.
+  - Go to the `Groups` tab.
+  - Click `Join Group`.
+  - Select the `Administrator` group and confirm the selection.
+
+Step 4: Assign Roles to the User in the `shared` Realm
+  - Go to the Role Mappings tab.
+  - In the Available Roles section, select the roles required for the user (e.g., `sonar-administrators`).
+  - Click Assign to apply the roles.
+
+Result: The user will now be able to:
+
+- Access resources assigned to the `Administrator` group.
+- Log in to SonarQube with the `sonar-administrators` role.
+
+For more details on permissions and the platform's authentication model, refer to the documentation:
+[KuberocketCI Documentation — Platform Authentication Model](https://docs.kuberocketci.io/docs/operator-guide/auth/platform-auth-model/)
+
+</details>
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/clusters/core/addons/kuberocketci-rbac/README.md.gotmpl
+++ b/clusters/core/addons/kuberocketci-rbac/README.md.gotmpl
@@ -87,6 +87,141 @@ AWS Parameter Store structure:
 
 </details>
 
+User Creation Process for Keycloak Integration Across Configurations
+
+<details>
+<summary><b>Examples 1: Users management without predefined broker realm:</b></summary>
+
+```
+broker:
+  # Create the broker realm with corresponding resources.
+  create: true
+  # If broker create parameter set to false operator create only a client for connection as Identity Provider,
+  # in this case be sure you define correct Realm name.
+  name: "broker"
+
+# Realm creating for connecting and managing shared services clients, such as Nexus, Sonar, DefectDojo, etc.
+sharedService: "shared"
+```
+
+Step-by-Step Guide to onboarding User:
+
+Step 1: Create a New User in the `broker` Realm:
+1. Go to the `broker` Realm.
+2. Navigate `Users` tab and click `Add User` button.
+3. Enter the following details:
+  * Username: A unique `username` (e.g., `developer123`).
+  * Email: The user's `email address` (e.g., `developer@example.com`).
+  * First Name: The user's `first name` (e.g., `John`).
+  * Last Name: The user's `last name` (e.g., `Doe`).
+4. Click Save to save the user's details.
+5. Go to the `Credentials` tab:
+  * Click `Set Password` button.
+  * Enter the new password twice.
+    Note: If the password is fixed, toggle the Temporary switch to Off.
+(Otherwise, the user will be prompted to change the password upon their first login).
+6. Go to the Details tab:
+   Copy the `User ID` and `Username`. These values will be required for the next step.
+
+Step 2: Link the User in the `shared` Realm
+1. Go to the `shared` Realm.
+2. Open `Users` tab and click `Add User` button.
+3. Set the same `username` from `step 1.3`.
+4. Click Save to create the user.
+5. Open the newly created user, go to the `Identity Provider` Links tab:
+   Provide the following details from the `step 1.6`:
+   * User ID: The `ID` of user copied from the Details tab in the `broker` Realm.
+   * Username: The `Username` of user copied from the Details tab in the `broker` Realm.
+   * Click `Link` to complete the association.
+
+Step 3: Assign Groups to the User in the `shared` Realm
+  - Open the user in the `shared` Realm.
+  - Go to the `Groups` tab.
+  - Click `Join Group`.
+  - Select the `Developer` group and confirm the selection.
+
+Step 4: Assign Roles to the User in the `shared` Realm
+  - Go to the Role Mappings tab.
+  - In the Available Roles section, select the roles required for the user (e.g., `sonar-developers`).
+  - Click Assign to apply the roles.
+
+Result: The user will now be able to:
+
+- Access resources assigned to the `Developer` group.
+- Log in to SonarQube with the `sonar-developers` role.
+
+For more details on permissions and the platform's authentication model, refer to the documentation:
+[KuberocketCI Documentation — Platform Authentication Model](https://docs.kuberocketci.io/docs/operator-guide/auth/platform-auth-model/)
+
+</details>
+
+<details>
+<summary><b>Example 2: Users management with predefined broker realm:</b></summary>
+
+```
+broker:
+  # Create the broker realm with corresponding resources.
+  create: false
+  # If broker create parameter set to false operator create only a client for connection as Identity Provider,
+  # in this case be sure you define correct Realm name.
+
+existingBroker: "project-realm"
+
+sharedService: "shared"
+```
+
+Step-by-Step Guide to onboarding User:
+
+(Optional step) if user does not exist in `project-broker` Realm:
+
+1. Go to the `project-broker` Realm.
+2. Navigate `Users` tab and click `Add User` button.
+3. Enter the following details:
+  * Username: A unique `username` (e.g., `developer123`).
+  * Email: The user's `email address` (e.g., `developer@example.com`).
+  * First Name: The user's `first name` (e.g., `John`).
+  * Last Name: The user's `last name` (e.g., `Doe`).
+4. Click Save to save the user's details.
+
+Step 1: Copy `username` and `ID` from existing `project-broker` Realm:
+1. Go to the `project-broker` Realm.
+2. Select `Users` tab.
+3. Enter the following details:
+4. Go to the Details tab:
+   Copy the `User ID` and `Username`. These values will be required for the next step.
+
+Step 2: Link the User in the `shared` Realm
+1. Go to the `shared` Realm.
+2. Navigate `Users` tab and click `Add User` button.
+3. Set the same `username` from `step 1.3`.
+4. Click Save to create the user.
+5. Open the newly created user, go to the `Identity Provider` Links tab:
+   Provide the following details from the `step 1.4`:
+   * User ID: The `ID` of user copied from the Details tab in the `broker` Realm.
+   * Username: The `Username` of user copied from the Details tab in the `broker` Realm.
+   * Click `Link` to complete the association.
+
+Step 3: Assign Groups to the User in the `shared` Realm
+  - Open the user in the `shared` Realm.
+  - Go to the `Groups` tab.
+  - Click `Join Group`.
+  - Select the `Administrator` group and confirm the selection.
+
+Step 4: Assign Roles to the User in the `shared` Realm
+  - Go to the Role Mappings tab.
+  - In the Available Roles section, select the roles required for the user (e.g., `sonar-administrators`).
+  - Click Assign to apply the roles.
+
+Result: The user will now be able to:
+
+- Access resources assigned to the `Administrator` group.
+- Log in to SonarQube with the `sonar-administrators` role.
+
+For more details on permissions and the platform's authentication model, refer to the documentation:
+[KuberocketCI Documentation — Platform Authentication Model](https://docs.kuberocketci.io/docs/operator-guide/auth/platform-auth-model/)
+
+</details>
+
 {{ template "chart.sourcesSection" . }}
 
 {{ template "chart.requirementsSection" . }}


### PR DESCRIPTION
# Pull Request Template

## Description
Standardize User Creation Process for Keycloak Integration Across Configurations:

Users management without a predefined broker realm.
Users management with predefined broker realm.

Fixes #(#217)

## Type of change

- [x] Documentation 

## How Has This Been Tested?
Deployed on development environment

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
