### PR TITLE
fix: Add annatation to grafana ingress for iframe(#213)

### DIFF
--- a/clusters/core/addons/prometheus-operator/README.md
+++ b/clusters/core/addons/prometheus-operator/README.md
@@ -106,6 +106,7 @@ AWS Parameter Store structure:
 | kube-prometheus-stack.grafana.admin.userKey | string | `"username"` |  |
 | kube-prometheus-stack.grafana.envFromSecret | string | `"keycloak-client-grafana-secret"` |  |
 | kube-prometheus-stack.grafana.fullnameOverride | string | `"grafana"` |  |
+| kube-prometheus-stack.grafana.ingress.annotations."nginx.ingress.kubernetes.io/configuration-snippet" | string | `"more_set_headers X-Frame-Options: none;"` |  |
 | kube-prometheus-stack.grafana.ingress.enabled | bool | `true` |  |
 | kube-prometheus-stack.grafana.ingress.hosts[0] | string | `"grafana.example.com"` |  |
 | kube-prometheus-stack.grafana.ingress.pathType | string | `"ImplementationSpecific"` |  |

--- a/clusters/core/addons/prometheus-operator/values.yaml
+++ b/clusters/core/addons/prometheus-operator/values.yaml
@@ -101,6 +101,10 @@ kube-prometheus-stack:
 
     ingress:
       enabled: true
+      annotations:
+        # This annotation is intended to configure NGINX so that the X-Frame-Options header does not block
+        # embedding of the grafana web in an iframe.
+        nginx.ingress.kubernetes.io/configuration-snippet: "more_set_headers X-Frame-Options: none;"
       hosts:
         - grafana.example.com
       paths:


### PR DESCRIPTION
# Pull Request Template

## Description
This annotation is intended to configure NGINX so that the X-Frame-Options header does not block embedding of the site in an iframe.

Fixes #(#213 )

## Type of change

- [x] fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Deployed on develop environment

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
