### PR TITLE
chore: Add post-install Helm hooks with delete policy(#213)

### DIFF
--- a/argo-cd/templates/appProjectCore.yaml
+++ b/argo-cd/templates/appProjectCore.yaml
@@ -2,6 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: core
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
   # Finalizer that ensures that project is not deleted until it is not referenced by any application
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argo-cd/templates/appProjectKRCI.yaml
+++ b/argo-cd/templates/appProjectKRCI.yaml
@@ -2,6 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: krci
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
   # Finalizer that ensures that project is not deleted until it is not referenced by any application
   finalizers:
     - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
## Description
This pull request adds to main ARGOCD Helm chart hooks to the AppProject configuration for the `krci` and `core` projects. Specifically, the `post-install` hook is added along with a delete policy of `before-hook-creation`. 

These annotations ensure that the defined Helm hooks are executed after the installation of the application, and the associated resources are deleted before a new hook is created. This change aims to improve the deployment flow and ensure a clean environment before any subsequent installations or updates.

Fixes (#213 )

## Type of change

- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

## How Has This Been Tested?
Deployed on develop environment.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
