### PR TITLE
chore: Add instructions for managing ArgoCD VCS secrets(#213)

### DIFF
--- a/argo-cd/README.md
+++ b/argo-cd/README.md
@@ -2,7 +2,70 @@
 
 ![Version: 7.7.11](https://img.shields.io/badge/Version-7.7.11-informational?style=flat-square) ![AppVersion: v2.13.2](https://img.shields.io/badge/AppVersion-v2.13.2-informational?style=flat-square)
 
-A Helm chart for Argo CD Install
+## Secret Management for VCS Integration
+
+1. <b>GitHub</b>
+
+To create a secret for connecting to GitHub:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@github.com:22/organization-name"
+EOF
+```
+
+2. <b>GitLab</b>
+
+To create a secret for connecting to GitLab:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@gitlab.com:22/organization-name"
+EOF
+```
+
+3. <b>Bitbucket</b>
+
+To create a secret for connecting to Bitbucket:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitbucket-ssh-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@bitbucket.org:22/organization-name"
+EOF
+```
+
+Important:
+
+The label `argocd.argoproj.io/secret-type: repo-creds` is mandatory for proper integration with ArgoCD. Without this label, ArgoCD may not recognize the secret as valid for VCS integration.
+
+Make sure the path to your SSH private key (~/.ssh/id_rsa) is correct. This key should be used to authenticate access to your GitHub, GitLab, or Bitbucket repository.
 
 ## Requirements
 
@@ -39,4 +102,3 @@ A Helm chart for Argo CD Install
 | eso.secretStoreName | string | `"aws-parameterstore"` | Defines Secret Store name. |
 | eso.type | string | `"aws"` | Defines provider type. One of `aws` or `generic`. |
 | oidc.enabled | bool | `false` |  |
-

--- a/argo-cd/README.md.gotmpl
+++ b/argo-cd/README.md.gotmpl
@@ -1,0 +1,79 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## Secret Management for VCS Integration
+
+1. <b>GitHub</b>
+
+To create a secret for connecting to GitHub:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@github.com:22/organization-name"
+EOF
+```
+
+2. <b>GitLab</b>
+
+To create a secret for connecting to GitLab:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@gitlab.com:22/organization-name"
+EOF
+```
+
+3. <b>Bitbucket</b>
+
+To create a secret for connecting to Bitbucket:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitbucket-ssh-credentials
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+data:
+  ssh-private-key: $(cat ~/.ssh/id_rsa | base64)
+  url: "ssh://git@bitbucket.org:22/organization-name"
+EOF
+```
+
+Important:
+
+The label `argocd.argoproj.io/secret-type: repo-creds` is mandatory for proper integration with ArgoCD. Without this label, ArgoCD may not recognize the secret as valid for VCS integration.
+
+Make sure the path to your SSH private key (~/.ssh/id_rsa) is correct. This key should be used to authenticate access to your GitHub, GitLab, or Bitbucket repository.
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}


### PR DESCRIPTION
## Description
Added Kubernetes secrets for ArgoCD VCS integration (GitHub, GitLab, Bitbucket).

- Created secrets to authenticate ArgoCD with GitHub, GitLab, and Bitbucket.
- Each secret contains an SSH private key and the repository URL.
- These secrets enable ArgoCD to securely sync repositories using SSH authentication.

Ensure the provided SSH key has access to the respective repositories before applying the secrets.

Fixes (#213)

## Type of change

- [x] Documentation

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
