### PR TITLE
Update External Secrets Operator Helm chart to v0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ make update-readme
 | awx-operator           | 2.19.1    | 2.19.1       | awx-operator           | False             | False    |
 | capsule                | 0.5.3     | 0.4.2        | capsule-system         | False             | False    |
 | capsule-tenant         | N/A       | N/A          | capsule-system         | N/A               | False    |
-| cert-manager           | 1.16.1    | v1.16.1      | cert-manager           | False             | False    |
+| cert-manager           | 1.17.1    | 1.17.1       | cert-manager           | False             | False    |
 | defectdojo             | 1.6.168   | 2.42.1       | defectdojo             | False             | False    |
 | dependency-track       | 0.26.0    | v4.12.4      | dependency-track       | False             | False    |
-| external-secrets       | 0.10.5    | 1.0          | external-secrets       | False             | False    |
+| external-secrets       | 0.14.2    | 0.14.2       | external-secrets       | False             | False    |
 | fluent-bit             | 0.46.11   | 3.0.7        | logging                | False             | False    |
 | harbor                 | 0.1.0     | 1.12.2       | harbor                 | False             | False    |
 | harbor-ha              | 1.13.0    | 2.9.0        | harbor                 | False             | False    |

--- a/clusters/core/addons/cert-manager/README.md
+++ b/clusters/core/addons/cert-manager/README.md
@@ -1,6 +1,6 @@
 # cert-manager
 
-![Version: 1.16.1](https://img.shields.io/badge/Version-1.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.16.1](https://img.shields.io/badge/AppVersion-v1.16.1-informational?style=flat-square)
+![Version: 1.17.1](https://img.shields.io/badge/Version-1.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.1](https://img.shields.io/badge/AppVersion-1.17.1-informational?style=flat-square)
 
 A Helm chart for Cert Manager
 
@@ -8,7 +8,7 @@ A Helm chart for Cert Manager
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.jetstack.io | cert-manager | 1.16.1 |
+| https://charts.jetstack.io | cert-manager | 1.17.1 |
 
 ## Values
 

--- a/clusters/core/addons/external-secrets/Chart.yaml
+++ b/clusters/core/addons/external-secrets/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.5
+version: 0.14.2
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.0"
+appVersion: "0.14.2"
 
 dependencies:
   - name: external-secrets
-    version: 0.10.5
+    version: 0.14.2
     repository: https://charts.external-secrets.io/

--- a/clusters/core/addons/external-secrets/README.md
+++ b/clusters/core/addons/external-secrets/README.md
@@ -1,6 +1,6 @@
 # external-secrets
 
-![Version: 0.10.5](https://img.shields.io/badge/Version-0.10.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.2](https://img.shields.io/badge/AppVersion-0.14.2-informational?style=flat-square)
 
 A Helm chart for the External Secrets operator
 
@@ -8,5 +8,5 @@ A Helm chart for the External Secrets operator
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.external-secrets.io/ | external-secrets | 0.10.5 |
+| https://charts.external-secrets.io/ | external-secrets | 0.14.2 |
 


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request updates the External Secrets Operator Helm chart to version v0.14.2.

Fixes #234

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Verified the updated Helm chart version in the `Chart.yaml` and `README.md`.
- Ensured the branch builds successfully and is ready for the merge.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit.

## Additional context
This update ensures that we are using the latest features and security updates provided by version 0.14.2 of the External Secrets Operator Helm chart.