### PR TITLE
chore: Adjust health check and TLS config for tekton-results

### DIFF
--- a/clusters/core/addons/tekton/results.yaml
+++ b/clusters/core/addons/tekton/results.yaml
@@ -562,7 +562,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
           name: api
@@ -570,7 +570,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:
@@ -587,7 +587,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
@@ -607,6 +607,7 @@ spec:
         - name: tls
           secret:
             secretName: tekton-results-tls
+            optional: true
         - name: pipeline-logs
           persistentVolumeClaim:
             claimName: logs
@@ -685,6 +686,7 @@ spec:
         - name: tls
           secret:
             secretName: tekton-results-tls
+            optional: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -734,8 +736,8 @@ spec:
             - $(TEKTON_RESULTS_API_SERVICE)
             - -auth_mode
             - $(AUTH_MODE)
-            - '-logs_api'
-            - '-summary_labels=tekton.dev/pipeline,app.edp.epam.com/codebase,app.edp.epam.com/codebasebranch,app.edp.epam.com/pipelinetype'
+            - "-logs_api"
+            - "-summary_labels=tekton.dev/pipeline,app.edp.epam.com/codebase,app.edp.epam.com/codebasebranch,app.edp.epam.com/pipelinetype"
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -780,6 +782,7 @@ spec:
         - name: tls
           secret:
             secretName: tekton-results-tls
+            optional: true
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Description
This change updates the livenessProbe path and makes the TLS secret optional in clusters/core/addons/tekton/results.yaml.
It improves compatibility with environments where TLS is not strictly required and aligns health checks with actual service endpoints.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

## How Has This Been Tested?
- Applied updated manifest to test cluster via Helm.
- Verified pod startup and health check behavior.
- Confirmed that TLS secret absence does not block deployment

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit. I squash my commits.
- [x] New and existing unit tests pass locally with my changes

## Additional context
This change is part of internal cluster hardening and simplification efforts