### PR TITLE
chore: upgrade DefectDojo from 2.50.0 to 2.55.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | capsule                      | 0.10.9    | 0.10.9       | capsule-system         | False             | False    |
 | capsule-tenant               | N/A       | N/A          | capsule-system         | N/A               | False    |
 | cert-manager                 | v1.18.2   | v1.18.2      | cert-manager           | False             | False    |
-| defectdojo                   | 1.6.205   | 2.50.0       | defectdojo             | False             | False    |
+| defectdojo                   | 1.9.12    | 2.55.2       | defectdojo             | False             | False    |
 | dependency-track             | 0.41.0    | v4.13.6      | dependency-track       | False             | False    |
 | external-secrets             | 0.18.2    | 0.18.2       | external-secrets       | False             | False    |
 | fluent-bit                   | 0.53.0    | 4.0.7        | logging                | False             | False    |

--- a/clusters/core/addons/defectdojo/Chart.yaml
+++ b/clusters/core/addons/defectdojo/Chart.yaml
@@ -6,13 +6,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.205
+version: 1.9.12
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.50.0
+appVersion: 2.55.2
 
 dependencies:
 - name: defectdojo
-  version: 1.6.205
+  version: 1.9.12
   repository: https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts

--- a/clusters/core/addons/defectdojo/README.md
+++ b/clusters/core/addons/defectdojo/README.md
@@ -1,6 +1,6 @@
 # defectdojo
 
-![Version: 1.6.205](https://img.shields.io/badge/Version-1.6.205-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.50.0](https://img.shields.io/badge/AppVersion-2.50.0-informational?style=flat-square)
+![Version: 1.9.12](https://img.shields.io/badge/Version-1.9.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.55.2](https://img.shields.io/badge/AppVersion-2.55.2-informational?style=flat-square)
 
 ## Secret management
 
@@ -69,7 +69,7 @@ AWS Parameter Store structure:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts | defectdojo | 1.6.205 |
+| https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts | defectdojo | 1.9.12 |
 
 ## Values
 
@@ -92,13 +92,17 @@ AWS Parameter Store structure:
 | defectdojo.fullnameOverride | string | `"defectdojo"` |  |
 | defectdojo.host | string | `"defectdojo.example.com"` |  |
 | defectdojo.initializer.run | bool | `true` |  |
+| defectdojo.postgresServer | string | `"defectdojo-primary.defectdojo.svc"` |  |
 | defectdojo.postgresql.auth.existingSecret | string | `"defectdojo-pguser-defectdojo"` |  |
 | defectdojo.postgresql.auth.secretKeys.adminPasswordKey | string | `"password"` |  |
 | defectdojo.postgresql.auth.secretKeys.userPasswordKey | string | `"password"` |  |
 | defectdojo.postgresql.enabled | bool | `false` |  |
-| defectdojo.postgresql.postgresServer | string | `"defectdojo-primary.defectdojo.svc"` |  |
-| defectdojo.redis.master.persistence.size | string | `"2Gi"` |  |
 | defectdojo.site_url | string | `"https://defectdojo.example.com"` |  |
+| defectdojo.valkey.auth.existingSecret | string | `"defectdojo-valkey-specific"` |  |
+| defectdojo.valkey.auth.existingSecretPasswordKey | string | `"valkey-password"` |  |
+| defectdojo.valkey.enabled | bool | `true` |  |
+| defectdojo.valkey.persistence.size | string | `"2Gi"` |  |
+| defectdojo.valkey.service.port | int | `6379` |  |
 | eso.aws | object | `{"region":"eu-central-1","roleArn":"arn:aws:iam::012345678910:role/AWSIRSA_Shared_ExternalSecretOperatorAccess"}` | AWS configuration (if provider is `aws`). |
 | eso.aws.region | string | `"eu-central-1"` | AWS region. |
 | eso.aws.roleArn | string | `"arn:aws:iam::012345678910:role/AWSIRSA_Shared_ExternalSecretOperatorAccess"` | AWS role ARN for the ExternalSecretOperator to assume. |

--- a/clusters/core/addons/defectdojo/templates/external-secrets/defectdojo-valkey-specific.yaml
+++ b/clusters/core/addons/defectdojo/templates/external-secrets/defectdojo-valkey-specific.yaml
@@ -2,14 +2,14 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: defectdojo-redis-specific
+  name: defectdojo-valkey-specific
 spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: {{ .Release.Name }}
   data:
-    - secretKey: redis-password
+    - secretKey: valkey-password
       remoteRef:
         key: {{ .Values.eso.secretPath }}
         property: defectdojo.redis-password

--- a/clusters/core/addons/defectdojo/values.yaml
+++ b/clusters/core/addons/defectdojo/values.yaml
@@ -20,20 +20,26 @@ defectdojo:
       persistentVolumeClaim:
         size: 2Gi
 
+  # External PostgreSQL (Crunchy PostgresCluster)
+  postgresServer: "defectdojo-primary.defectdojo.svc"
   postgresql:
-    # Crunch PostgresCluster is used as the External Postgresql database
     enabled: false
-    postgresServer: "defectdojo-primary.defectdojo.svc"
     auth:
       existingSecret: defectdojo-pguser-defectdojo
       secretKeys:
         adminPasswordKey: password
         userPasswordKey: password
 
-  redis:
-    master:
-      persistence:
-        size: 2Gi
+  # Valkey replaces Redis since chart 1.9.0
+  valkey:
+    enabled: true
+    auth:
+      existingSecret: defectdojo-valkey-specific
+      existingSecretPasswordKey: valkey-password
+    service:
+      port: 6379
+    persistence:
+      size: 2Gi
 
   # SSO Enablement. for additional options, please consult https://defectdojo.github.io/django-DefectDojo/integrations/social-authentication/#keycloak
   # Keycloak integration also requires DD_SOCIAL_AUTH_KEYCLOAK_SECRET to be defined, we recommend to create secret with name `defectdojo-extrasecrets`

--- a/clusters/core/apps/README.md
+++ b/clusters/core/apps/README.md
@@ -52,18 +52,14 @@ EDP Cluster Addons that extend the Kubernetes Cluster Functionality
 | gitfusion.createNamespace | bool | `false` |  |
 | gitfusion.enable | bool | `false` |  |
 | gitfusion.namespace | string | `"krci"` |  |
-| gitlab-runner.createNamespace | bool | `false` |  |
-| gitlab-runner.enable | bool | `false` |  |
-| gitlab-runner.namespace | string | `"gitlab-runner"` |  |
+| gitlab-runner | object | `{"createNamespace":false,"enable":false,"namespace":"gitlab-runner"}` | GitLab Runner |
+| harbor | object | `{"createNamespace":false,"enable":false,"namespace":"harbor"}` | Harbor |
 | harbor-ha-okd.createNamespace | bool | `false` |  |
 | harbor-ha-okd.enable | bool | `false` |  |
 | harbor-ha-okd.namespace | string | `"harbor"` |  |
 | harbor-ha.createNamespace | bool | `false` |  |
 | harbor-ha.enable | bool | `false` |  |
 | harbor-ha.namespace | string | `"harbor"` |  |
-| harbor.createNamespace | bool | `false` |  |
-| harbor.enable | bool | `false` |  |
-| harbor.namespace | string | `"harbor"` |  |
 | ingress-nginx-external.createNamespace | bool | `false` |  |
 | ingress-nginx-external.enable | bool | `false` |  |
 | ingress-nginx-external.namespace | string | `"ingress-nginx-external"` |  |


### PR DESCRIPTION
- Update chart version from 1.6.205 to 1.9.12
- Migrate Redis to Valkey as the cache backend (chart 1.9.0+)
- Restructure PostgreSQL configuration with top-level postgresServer value
- Rename external secret from defectdojo-redis-specific to defectdojo-valkey-specific
- Configure Valkey persistence, authentication, and service port
- Update all references to match new Helm chart structure and breaking changes
