### PR TITLE
chore: Bump keycloak-operator to 1.34.0 (#405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | keda                         | 2.17.2    | 2.17.2       | keda                   | False             | False    |
 | keycloak                     | 2.3.0     | 24.0.4       | security               | False             | False    |
 | keycloak-postgresql          | 0.1.1     | 1.0          | security               | False             | False    |
-| keycloak-operator            | 1.32.0    | 1.32.0       | keycloak-operator      | False             | False    |
+| keycloak-operator            | 1.34.0    | 1.34.0       | keycloak-operator      | False             | False    |
 | krakend                      | 0.1.36    | 2.7.2        | krci-krakend           | False             | False    |
 | kuberocketci-pipelines       | N/A       | N/A          | krci                   | False             | False    |
 | kuberocketci-rbac            | 0.1.0     | 0.1.0        | krci-security          | False             | False    |

--- a/clusters/core/addons/keycloak-operator/Chart.yaml
+++ b/clusters/core/addons/keycloak-operator/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 description: A Helm chart for keycloak-operator
 name: keycloak-operator
 type: application
-version: 1.32.0
-appVersion: 1.32.0
+version: 1.34.0
+appVersion: 1.34.0
 
 dependencies:
 - name: keycloak-operator
-  version: 1.32.0
+  version: 1.34.0
   repository: https://epam.github.io/edp-helm-charts/stable

--- a/clusters/core/addons/keycloak-operator/README.md
+++ b/clusters/core/addons/keycloak-operator/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.32.0](https://img.shields.io/badge/Version-1.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
+![Version: 1.34.0](https://img.shields.io/badge/Version-1.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.34.0](https://img.shields.io/badge/AppVersion-1.34.0-informational?style=flat-square)
 
 A Helm chart for keycloak-operator
 
@@ -8,7 +8,7 @@ A Helm chart for keycloak-operator
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://epam.github.io/edp-helm-charts/stable | keycloak-operator | 1.32.0 |
+| https://epam.github.io/edp-helm-charts/stable | keycloak-operator | 1.34.0 |
 
 ## Values
 


### PR DESCRIPTION
## Description
This change updates the keycloak-operator add-on to the 1.34.0 version.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
make helm-docs

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
