### PR TITLE
EPMDEDP-17078: chore: Update sonar-findbugs plugin to v4.6.0

### DIFF
--- a/clusters/core/addons/sonar/README.md
+++ b/clusters/core/addons/sonar/README.md
@@ -55,7 +55,7 @@ A Helm chart for Sonarqube
 | sonarqube.nameOverride | string | `"sonar"` |  |
 | sonarqube.plugins.install[0] | string | `"https://github.com/sonar-auth-oidc/sonar-auth-oidc/releases/download/v3.0.0/sonar-auth-oidc-plugin-3.0.0.jar"` |  |
 | sonarqube.plugins.install[1] | string | `"https://github.com/checkstyle/sonar-checkstyle/releases/download/10.20.1/checkstyle-sonar-plugin-10.20.1.jar"` |  |
-| sonarqube.plugins.install[2] | string | `"https://github.com/spotbugs/sonar-findbugs/releases/download/4.2.9/sonar-findbugs-plugin-4.2.9.jar"` |  |
+| sonarqube.plugins.install[2] | string | `"https://github.com/spotbugs/sonar-findbugs/releases/download/v4.6.0/sonar-findbugs-plugin-v4.6.0.jar"` |  |
 | sonarqube.plugins.install[3] | string | `"https://github.com/jborgers/sonar-pmd/releases/download/3.5.1/sonar-pmd-plugin-3.5.1.jar"` |  |
 | sonarqube.plugins.install[4] | string | `"https://github.com/sbaudoin/sonar-ansible/releases/download/v2.5.1/sonar-ansible-plugin-2.5.1.jar"` |  |
 | sonarqube.plugins.install[5] | string | `"https://github.com/sbaudoin/sonar-yaml/releases/download/v1.9.1/sonar-yaml-plugin-1.9.1.jar"` |  |

--- a/clusters/core/addons/sonar/values.yaml
+++ b/clusters/core/addons/sonar/values.yaml
@@ -27,7 +27,7 @@ sonarqube:
     install:
       - "https://github.com/sonar-auth-oidc/sonar-auth-oidc/releases/download/v3.0.0/sonar-auth-oidc-plugin-3.0.0.jar"
       - "https://github.com/checkstyle/sonar-checkstyle/releases/download/10.20.1/checkstyle-sonar-plugin-10.20.1.jar"
-      - "https://github.com/spotbugs/sonar-findbugs/releases/download/4.2.9/sonar-findbugs-plugin-4.2.9.jar"
+      - "https://github.com/spotbugs/sonar-findbugs/releases/download/v4.6.0/sonar-findbugs-plugin-v4.6.0.jar"
       - "https://github.com/jborgers/sonar-pmd/releases/download/3.5.1/sonar-pmd-plugin-3.5.1.jar"
       - "https://github.com/sbaudoin/sonar-ansible/releases/download/v2.5.1/sonar-ansible-plugin-2.5.1.jar"
       - "https://github.com/sbaudoin/sonar-yaml/releases/download/v1.9.1/sonar-yaml-plugin-1.9.1.jar"


### PR DESCRIPTION
## Description
Update sonar-findbugs (SpotBugs) SonarQube plugin from 4.2.9 to v4.6.0. 
Starting from v4.6.0, the release tag and JAR filename include the v prefix, so both the download path and filename in the URL have been updated accordingly.

Relates to EPMDEDP-17078

## Type of change
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

## How Has This Been Tested?
Plugin version verified against the official SpotBugs SonarQube plugin release (https://github.com/spotbugs/sonar-findbugs/releases/tag/v4.6.0). URL accessibility confirmed.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit. I squash my commits.