### PR TITLE
EPMDEDP-17076: chore: Update Tekton Chains to v0.27.0

### DIFF
--- a/clusters/core/addons/tekton/chains.yaml
+++ b/clusters/core/addons/tekton/chains.yaml
@@ -63,8 +63,8 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-chains
-    pipeline.tekton.dev/release: "v0.26.0"
-    version: "v0.26.0"
+    pipeline.tekton.dev/release: "v0.27.0"
+    version: "v0.27.0"
 spec:
   replicas: 1
   selector:
@@ -84,13 +84,13 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/part-of: tekton-chains
         # # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.26.0"
-        version: "v0.26.0"
+        pipeline.tekton.dev/release: "v0.27.0"
+        version: "v0.27.0"
     spec:
       serviceAccountName: tekton-chains-controller
       containers:
         - name: tekton-chains-controller
-          image: ghcr.io/tektoncd/chains/controller-92006fd957c0afd31de6a40b3e33b39f:v0.26.0@sha256:c3167b2a72e0abc64032a3ce28e738d9b15a2e227e01de1063d7335a0ea1da28
+          image: ghcr.io/tektoncd/chains/github.com/tektoncd/chains/cmd/controller:v0.27.0@sha256:a92aa5ba9e05aef7da224a208d79d6fb321fac943836905a894b0c1a25796eb3
           volumeMounts:
             - name: signing-secrets
               mountPath: /etc/signing-secrets
@@ -351,7 +351,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace, we can still access
   # this ConfigMap.
-  version: "v0.26.0"
+  version: "v0.27.0"
 
 ---
 # Copyright 2023 Tekton Authors LLC
@@ -485,6 +485,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-chains
 data:
+  # metrics-protocol specifies the OpenTelemetry export protocol for metrics.
+  # Supported values: prometheus (default), grpc, http/protobuf, none.
+  metrics-protocol: prometheus
   _example: |
     ################################
     #                              #
@@ -500,26 +503,20 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
     #
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using Stackdriver will incur additional charges.
+    # metrics-protocol specifies the OpenTelemetry export protocol.
+    # Supported values: prometheus (default), grpc, http/protobuf, none.
     #
-    metrics.backend-destination: prometheus
+    metrics-protocol: prometheus
     #
-    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used and metrics will be sent to the cluster's project if this field is
-    # not provided.
+    # metrics-endpoint is the OTLP collector endpoint to send metrics to.
+    # Required when metrics-protocol is grpc or http/protobuf.
     #
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    metrics-endpoint: "otel-collector.observability.svc.cluster.local:4317"
     #
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
-    # to send metrics to Stackdriver using "global" resource type and custom
-    # metric type. Setting this flag to "true" could cause extra Stackdriver
-    # charge.  If metrics.backend-destination is not Stackdriver, this is
-    # ignored.
+    # metrics-export-interval is the interval at which metrics are exported.
+    # Uses Go duration format (e.g. 30s, 1m). Defaults to 30s.
     #
-    metrics.allow-stackdriver-custom-metrics: "false"
+    metrics-export-interval: 30s
 
 ---
 # Copyright 2023 Tekton Authors LLC


### PR DESCRIPTION
## Description
Update Tekton Chains from v0.26.0 to v0.27.0.

Release: https://github.com/tektoncd/chains/releases/tag/v0.27.0

Note: `tekton-chains-config-observability` metrics configuration updated from legacy Stackdriver-based keys (`metrics.backend-destination`) to OpenTelemetry `metrics-protocol` key introduced in v0.27.0.

Relates to EPMDEDP-17076

## Type of change
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

## Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit. I squash my commits.

## Additional context
Only `clusters/core/addons/tekton/chains.yaml` is changed. Resource limits and `signing-secrets` placeholder preserved as-is from the previous version.