### PR TITLE
EPMDEDP-17126: feat: Add envoy-gateway add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | harbor                       | 0.1.0     | 1.17.2       | harbor                 | False             | False    |
 | harbor-ha                    | 1.17.2    | 2.9.0        | harbor                 | False             | False    |
 | harbor-ha-okd                | 1.13.0    | 2.9.0        | harbor                 | False             | False    |
+| envoy-gateway                | 1.8.1     | 1.8.1        | envoy-gateway-system   | False             | False    |
+| envoy-gateway-resources      | 1.8.1     | 1.8.1        | envoy-gateway-system   | False             | False    |
 | ingress-nginx                | 4.15.0    | 1.15.0       | ingress-nginx          | False             | False    |
 | ingress-nginx-external       | 4.15.0    | 1.15.0       | ingress-nginx-external | False             | False    |
 | jaeger-operator              | 2.57.0    | 1.61.0       | jaeger-operator        | False             | False    |

--- a/clusters/core/addons/envoy-gateway-resources/Chart.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: envoy-gateway-resources
+description: Envoy Gateway custom resources (GatewayClass, Gateway, EnvoyProxy, ClientTrafficPolicy, BackendTrafficPolicy)
+type: application
+version: 1.8.1
+appVersion: "1.8.1"

--- a/clusters/core/addons/envoy-gateway-resources/README.md
+++ b/clusters/core/addons/envoy-gateway-resources/README.md
@@ -1,0 +1,6 @@
+# envoy-gateway-resources
+
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+
+Envoy Gateway custom resources (GatewayClass, Gateway, EnvoyProxy, ClientTrafficPolicy, BackendTrafficPolicy)
+

--- a/clusters/core/addons/envoy-gateway-resources/templates/backend-traffic-policy.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/templates/backend-traffic-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: main-gateway-defaults
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: main-gateway
+  timeout:
+    tcp:
+      connectTimeout: 10s
+    http:
+      requestTimeout: 30s
+  retry:
+    numRetries: 2
+    retryOn:
+      httpStatusCodes:
+        - 502
+        - 503
+        - 504
+      triggers:
+        - connect-failure
+        - reset

--- a/clusters/core/addons/envoy-gateway-resources/templates/client-traffic-policy.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/templates/client-traffic-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: http-policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: main-gateway
+  clientIPDetection:
+    xForwardedFor:
+      numTrustedHops: 1
+  headers:
+    lateResponseHeaders:
+      set:
+        - name: X-Content-Type-Options
+          value: nosniff
+        - name: X-Frame-Options
+          value: SAMEORIGIN
+        - name: Strict-Transport-Security
+          value: max-age=63072000; includeSubDomains

--- a/clusters/core/addons/envoy-gateway-resources/templates/envoy-proxy.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/templates/envoy-proxy.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: http-proxy
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        # NodePort so no cloud LoadBalancer is provisioned. NodePort numbers are
+        # auto-assigned; override per cluster via a StrategicMerge patch if a fixed
+        # port is required (e.g. to align with an existing ingress front-end).
+        type: NodePort

--- a/clusters/core/addons/envoy-gateway-resources/templates/gateway-class.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/templates/gateway-class.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: http-class
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: http-proxy
+    namespace: envoy-gateway-system

--- a/clusters/core/addons/envoy-gateway-resources/templates/gateway.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/templates/gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+spec:
+  gatewayClassName: http-class
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/clusters/core/addons/envoy-gateway-resources/values.yaml
+++ b/clusters/core/addons/envoy-gateway-resources/values.yaml
@@ -1,0 +1,3 @@
+# This add-on ships static Gateway API custom resources; there are no configurable
+# Helm values. NodePort numbers are auto-assigned — override the EnvoyProxy
+# envoyService via a StrategicMerge patch per cluster if a fixed port is required.

--- a/clusters/core/addons/envoy-gateway/Chart.yaml
+++ b/clusters/core/addons/envoy-gateway/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: envoy-gateway
+description: A Helm chart for the Envoy Gateway controller
+type: application
+version: 1.8.1
+appVersion: "1.8.1"
+dependencies:
+  - name: gateway-helm
+    version: "1.8.1"
+    repository: "oci://docker.io/envoyproxy"

--- a/clusters/core/addons/envoy-gateway/README.md
+++ b/clusters/core/addons/envoy-gateway/README.md
@@ -1,0 +1,18 @@
+# envoy-gateway
+
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+
+A Helm chart for the Envoy Gateway controller
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://docker.io/envoyproxy | gateway-helm | 1.8.1 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| gateway-helm | object | `{}` |  |
+

--- a/clusters/core/addons/envoy-gateway/values.yaml
+++ b/clusters/core/addons/envoy-gateway/values.yaml
@@ -1,0 +1,3 @@
+# Envoy Gateway controller (gateway-helm). Controller defaults are sufficient;
+# the Gateway API custom resources are managed by the envoy-gateway-resources add-on.
+gateway-helm: {}

--- a/clusters/core/apps/README.md
+++ b/clusters/core/apps/README.md
@@ -43,6 +43,12 @@ EDP Cluster Addons that extend the Kubernetes Cluster Functionality
 | dependency-track.enable | bool | `false` |  |
 | dependency-track.namespace | string | `"dependency-track"` |  |
 | destinationServer | string | `"in-cluster"` |  |
+| envoy-gateway-resources.createNamespace | bool | `false` |  |
+| envoy-gateway-resources.enable | bool | `false` |  |
+| envoy-gateway-resources.namespace | string | `"envoy-gateway-system"` |  |
+| envoy-gateway.createNamespace | bool | `false` |  |
+| envoy-gateway.enable | bool | `false` |  |
+| envoy-gateway.namespace | string | `"envoy-gateway-system"` |  |
 | external-secrets.createNamespace | bool | `false` |  |
 | external-secrets.enable | bool | `false` |  |
 | external-secrets.namespace | string | `"external-secrets"` |  |

--- a/clusters/core/apps/templates/envoy-gateway-resources.yaml
+++ b/clusters/core/apps/templates/envoy-gateway-resources.yaml
@@ -1,0 +1,30 @@
+{{- if and (index .Values "envoy-gateway-resources") (index .Values "envoy-gateway-resources" "enable") -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.destinationServer}}-envoy-gateway-resources
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.argoProject | default "default" }}
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: clusters/{{ .Values.clusterName }}/addons/envoy-gateway-resources
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      releaseName: envoy-gateway-resources
+  destination:
+    name: {{ .Values.destinationServer | default "in-cluster" }}
+    namespace: {{ index .Values "envoy-gateway-resources" "namespace" }}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace={{ (index .Values "envoy-gateway-resources" "createNamespace") }}
+      - ServerSideApply=true
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+{{- end -}}

--- a/clusters/core/apps/templates/envoy-gateway.yaml
+++ b/clusters/core/apps/templates/envoy-gateway.yaml
@@ -1,0 +1,30 @@
+{{- if and (index .Values "envoy-gateway") (index .Values "envoy-gateway" "enable") -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.destinationServer}}-envoy-gateway
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.argoProject | default "default" }}
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: clusters/{{ .Values.clusterName }}/addons/envoy-gateway
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      releaseName: envoy-gateway
+  destination:
+    name: {{ .Values.destinationServer | default "in-cluster" }}
+    namespace: {{ index .Values "envoy-gateway" "namespace" }}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace={{ (index .Values "envoy-gateway" "createNamespace") }}
+      - ServerSideApply=true
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+{{- end -}}

--- a/clusters/core/apps/values.yaml
+++ b/clusters/core/apps/values.yaml
@@ -113,6 +113,16 @@ harbor-ha-okd:
   enable: false
   namespace: harbor
 
+envoy-gateway:
+  createNamespace: false
+  enable: false
+  namespace: envoy-gateway-system
+
+envoy-gateway-resources:
+  createNamespace: false
+  enable: false
+  namespace: envoy-gateway-system
+
 ingress-nginx:
   createNamespace: false
   enable: false


### PR DESCRIPTION
## Description
Add Envoy Gateway v1.8.1 as a new add-on for the KubeRocketCI cluster add-ons
catalog, split into two opt-in Argo CD Applications:
- `envoy-gateway` — the controller (Helm wrapper over upstream `gateway-helm`;
  installs the Gateway API + Envoy CRDs).
- `envoy-gateway-resources` — the Gateway API custom resources (GatewayClass,
  Gateway, EnvoyProxy, ClientTrafficPolicy, BackendTrafficPolicy).

Envoy Gateway implements the Kubernetes Gateway API and runs alongside
ingress-nginx in coexistence mode — existing Ingress resources are not affected.

Why two Applications: the controller + CRDs are synced first; the custom resources
are a separate Application synced after the controller is healthy. This avoids the
CRD-before-CR ordering race a single Application hits on first sync, and ensures the
controller is up before it must reconcile the CRs.

Both add-ons are disabled by default (`enable: false`). Generic defaults: EnvoyProxy
uses `NodePort` (no cloud LoadBalancer), NodePort numbers auto-assigned (override per
cluster via a StrategicMerge patch); real client IP via X-Forwarded-For
(`numTrustedHops: 1`); response security headers; default upstream timeouts/retries.

Relates to EPMDEDP-17126

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Full local install on a single-node cluster (controller + resources):
- Controller installed from the `gateway-helm` OCI chart; CRDs installed; controller
  pod Running.
- Custom resources applied cleanly: GatewayClass Accepted=True, Gateway
  Programmed=True, ClientTrafficPolicy and BackendTrafficPolicy Accepted=True,
  data-plane Envoy Proxy pod Running.
- Data-plane Service exposed as NodePort;

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit. I squash my commits.

## Additional context
- The `gateway-helm` OCI chart (v1.8.1) bundles the Gateway API + Envoy CRDs as a
  sub-chart — no separate CRD install step.
- `ServerSideApply=true` is set on both Applications to handle the large Gateway API
  CRDs (256KB client-side annotation limit).
- Sync order: `envoy-gateway` first (controller + CRDs), then `envoy-gateway-resources`.