### PR TITLE
EPMDEDP-17151: feat: add krci-audit add-on to the core GitOps catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | keycloak-postgresql          | 0.1.1     | 1.0          | security               | False             | False    |
 | keycloak-operator            | 1.34.0    | 1.34.0       | keycloak-operator      | False             | False    |
 | krakend                      | 0.1.36    | 2.7.2        | krci-krakend           | False             | False    |
+| krci-audit                   | 0.1.0     | 0.1.0        | krci-audit             | True              | False    |
 | kuberocketci-pipelines       | N/A       | N/A          | krci                   | False             | False    |
 | kuberocketci-rbac            | 0.1.0     | 0.1.0        | krci-security          | False             | False    |
 | kuberocketci                 | 3.13.5    | 3.13.5       | krci                   | False             | False    |

--- a/clusters/core/addons/krci-audit/Chart.yaml
+++ b/clusters/core/addons/krci-audit/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+description: A Helm chart for the KubeRocketCI krci-audit add-on — admission audit capture, store, and read API
+home: https://docs.kuberocketci.io/
+name: krci-audit
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+
+dependencies:
+- name: krci-audit
+  version: 0.1.0
+  repository: https://epam.github.io/edp-helm-charts/stable

--- a/clusters/core/addons/krci-audit/README.md
+++ b/clusters/core/addons/krci-audit/README.md
@@ -1,0 +1,53 @@
+# krci-audit
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+A Helm chart for the KubeRocketCI krci-audit add-on — admission audit capture, store, and read API
+
+**Homepage:** <https://docs.kuberocketci.io/>
+
+This add-on is a thin wrapper: it installs the `krci-audit` component chart and only overrides
+`db.mode`. Capture, storage, the read API, and scheduled partition retention are all configured
+in the component chart's own `values.yaml`.
+
+## Database credentials
+
+The component chart **never generates DB credentials** — it only reads a Secret you supply, in
+every `db.mode` (including the default `simple`, which provisions the in-cluster Postgres but not
+its Secret). Before enabling this add-on, provide the `krci-audit-db-access` Secret one of two ways:
+
+- **External Secrets Operator** (recommended for GitOps): enable the `eso` block in `values.yaml`, or
+- **Pre-create the Secret** once:
+
+  ```bash
+  kubectl -n krci-audit create secret generic krci-audit-db-access \
+    --from-literal=db-owner-username=krci-audit \
+    --from-literal=db-owner-password="$(openssl rand -base64 24)" \
+    --from-literal=writer-password="$(openssl rand -base64 24)" \
+    --from-literal=reader-password="$(openssl rand -base64 24)"
+  ```
+
+  `db-owner-*` is required for `simple` mode (it initializes the in-cluster Postgres);
+  `writer-password` always; `reader-password` only when the read API is enabled. For
+  `external`/`pgo`, point `db.owner.secretName` at your DB / operator Secret and keep only the
+  writer/reader keys here.
+
+## Retention
+
+Scheduled cleanup is on by default (keep 12 months, nightly). The component-chart defaults are
+shown commented in `values.yaml` — uncomment the `retention` block to override. Note it is
+**month-granular**: `months` is a whole number and data is dropped a whole monthly partition at
+a time, so the smallest effective window is ~1 month (sub-monthly windows such as 3 weeks are not
+supported).
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://epam.github.io/edp-helm-charts/stable | krci-audit | 0.1.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| krci-audit.db.mode | string | `"simple"` | Provisioning mode for the component's PostgreSQL (external | pgo | simple). `simple` runs a self-contained in-cluster Postgres (dev/small installs); use `external` (set db.host + db.owner.secretName) or `pgo` for production. Credentials are a prerequisite in every mode (see the header note) — the chart provisions the DB in simple/pgo, never its Secret. |

--- a/clusters/core/addons/krci-audit/README.md.gotmpl
+++ b/clusters/core/addons/krci-audit/README.md.gotmpl
@@ -1,0 +1,46 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+This add-on is a thin wrapper: it installs the `krci-audit` component chart and only overrides
+`db.mode`. Capture, storage, the read API, and scheduled partition retention are all configured
+in the component chart's own `values.yaml`.
+
+## Database credentials
+
+The component chart **never generates DB credentials** — it only reads a Secret you supply, in
+every `db.mode` (including the default `simple`, which provisions the in-cluster Postgres but not
+its Secret). Before enabling this add-on, provide the `krci-audit-db-access` Secret one of two ways:
+
+- **External Secrets Operator** (recommended for GitOps): enable the `eso` block in `values.yaml`, or
+- **Pre-create the Secret** once:
+
+  ```bash
+  kubectl -n krci-audit create secret generic krci-audit-db-access \
+    --from-literal=db-owner-username=krci-audit \
+    --from-literal=db-owner-password="$(openssl rand -base64 24)" \
+    --from-literal=writer-password="$(openssl rand -base64 24)" \
+    --from-literal=reader-password="$(openssl rand -base64 24)"
+  ```
+
+  `db-owner-*` is required for `simple` mode (it initializes the in-cluster Postgres);
+  `writer-password` always; `reader-password` only when the read API is enabled. For
+  `external`/`pgo`, point `db.owner.secretName` at your DB / operator Secret and keep only the
+  writer/reader keys here.
+
+## Retention
+
+Scheduled cleanup is on by default (keep 12 months, nightly). The component-chart defaults are
+shown commented in `values.yaml` — uncomment the `retention` block to override. Note it is
+**month-granular**: `months` is a whole number and data is dropped a whole monthly partition at
+a time, so the smallest effective window is ~1 month (sub-monthly windows such as 3 weeks are not
+supported).
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/clusters/core/addons/krci-audit/values.yaml
+++ b/clusters/core/addons/krci-audit/values.yaml
@@ -1,0 +1,40 @@
+# Configuration for the krci-audit component chart (subchart, pulled from edp-stable). Capture,
+# store, retention, TLS and the read API are all component-chart features; this add-on only
+# overrides the few values an operator commonly changes. The full surface lives in the
+# component chart's own values.yaml.
+#
+# Credentials: the component chart NEVER generates DB credentials — it only reads a Secret you
+# supply. This holds for every db.mode, including the default `simple` (which provisions the
+# in-cluster Postgres but not its Secret). Before enabling this add-on, pre-create the
+# `krci-audit-db-access` Secret (the add-on README has the exact command) or populate it via the
+# External Secrets Operator (enable the `eso` block below).
+krci-audit:
+  db:
+    # -- Provisioning mode for the component's PostgreSQL (external | pgo | simple). `simple` runs
+    # a self-contained in-cluster Postgres (dev/small installs); use `external` (set db.host +
+    # db.owner.secretName) or `pgo` for production. Credentials are a prerequisite in every mode
+    # (see the header note) — the chart provisions the DB in simple/pgo, never its Secret.
+    mode: simple
+
+  # Scheduled partition retention. The values below are the component-chart DEFAULTS (already
+  # active) — uncomment and change any of them to override.
+  #
+  # Retention is MONTH-GRANULAR: `months` is a whole number and expired data is dropped one whole
+  # monthly partition at a time (cheap, append-only-safe). The smallest effective window is
+  # therefore ~1 month — `months: 1` keeps the current partial month plus the previous month, so
+  # sub-monthly windows (e.g. "last 3 weeks") are NOT supported.
+  # retention:
+  #   enabled: true            # turn the nightly cleanup on/off
+  #   months: 12               # months of history to keep (whole number; minimum 1)
+  #   schedule: "0 2 * * *"    # cron for the cleanup job (default: nightly at 02:00)
+  #   createAheadMonths: 3     # future monthly partitions to pre-create (ingestion runway)
+
+  # Optional: populate the db-access Secret from an external store via the External Secrets
+  # Operator — the recommended way to satisfy the credential prerequisite for GitOps (no Secret
+  # committed or created by hand). Requires the external-secrets add-on. Uncomment and fill in:
+  # eso:
+  #   enabled: true
+  #   secretPath: /kuberocketci/krci-audit/db-access
+  #   aws:
+  #     region: us-east-1
+  #     roleArn: arn:aws:iam::<account-id>:role/<irsa-role>

--- a/clusters/core/apps/README.md
+++ b/clusters/core/apps/README.md
@@ -98,6 +98,9 @@ EDP Cluster Addons that extend the Kubernetes Cluster Functionality
 | krakend.createNamespace | bool | `false` |  |
 | krakend.enable | bool | `false` |  |
 | krakend.namespace | string | `"krci-krakend"` |  |
+| krci-audit.createNamespace | bool | `true` |  |
+| krci-audit.enable | bool | `false` |  |
+| krci-audit.namespace | string | `"krci-audit"` |  |
 | kuberocketci-pipelines.createNamespace | bool | `false` |  |
 | kuberocketci-pipelines.enable | bool | `false` |  |
 | kuberocketci-pipelines.namespace | string | `"krci"` |  |

--- a/clusters/core/apps/templates/krci-audit.yaml
+++ b/clusters/core/apps/templates/krci-audit.yaml
@@ -1,0 +1,29 @@
+{{- if and (index .Values "krci-audit") (index .Values "krci-audit" "enable") -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.destinationServer}}-krci-audit
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.argoProject | default "default" }}
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: clusters/{{ .Values.clusterName }}/addons/krci-audit
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      releaseName: krci-audit
+  destination:
+    name: {{ .Values.destinationServer | default "in-cluster" }}
+    namespace: {{ index .Values "krci-audit" "namespace" }}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace={{ (index .Values "krci-audit" "createNamespace") }}
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+{{- end -}}

--- a/clusters/core/apps/values.yaml
+++ b/clusters/core/apps/values.yaml
@@ -186,6 +186,12 @@ krakend:
   enable: false
   namespace: krci-krakend
 
+# KubeRocketCI admission audit — capture, store, read API, and scheduled retention. More details at https://docs.kuberocketci.io/
+krci-audit:
+  createNamespace: true
+  enable: false
+  namespace: krci-audit
+
 kuberocketci-pipelines:
   createNamespace: false
   enable: false


### PR DESCRIPTION
- Add the krci-audit add-on chart (Chart, values, README) under clusters/core/addons and register it as an Argo CD Application in the core App-of-Apps.
- Wire the add-on into clusters/core/apps values and refresh the catalog READMEs.

