### PR TITLE
EPMDEDP-17194: chore: Upgrade KubeRocketCI addon to 3.14.0 and Envoy values

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | krci-audit                   | 0.1.0     | 0.1.0        | krci-audit             | True              | False    |
 | kuberocketci-pipelines       | N/A       | N/A          | krci                   | False             | False    |
 | kuberocketci-rbac            | 0.1.0     | 0.1.0        | krci-security          | False             | False    |
-| kuberocketci                 | 3.13.5    | 3.13.5       | krci                   | False             | False    |
+| kuberocketci                 | 3.14.0    | 3.14.0       | krci                   | False             | False    |
 | minio-operator               | 7.1.1     | v7.1.1       | minio-operator         | False             | False    |
 | moon                         | 2.7.11    | 2.7.11       | moon                   | False             | False    |
 | nexus-ce                     | 0.1.1     | 3.82.0       | nexus                  | False             | False    |

--- a/clusters/core/addons/kuberocketci/Chart.yaml
+++ b/clusters/core/addons/kuberocketci/Chart.yaml
@@ -3,10 +3,10 @@ description: A Helm chart for KubeRocketCI Platform
 home: https://docs.kuberocketci.io/
 name: edp-install
 type: application
-version: 3.13.5
-appVersion: 3.13.5
+version: 3.14.0
+appVersion: 3.14.0
 
 dependencies:
 - name: edp-install
-  version: 3.13.5
+  version: 3.14.0
   repository: https://epam.github.io/edp-helm-charts/stable

--- a/clusters/core/addons/kuberocketci/README.md
+++ b/clusters/core/addons/kuberocketci/README.md
@@ -1,6 +1,6 @@
 # edp-install
 
-![Version: 3.13.5](https://img.shields.io/badge/Version-3.13.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.13.5](https://img.shields.io/badge/AppVersion-3.13.5-informational?style=flat-square)
+![Version: 3.14.0](https://img.shields.io/badge/Version-3.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.0](https://img.shields.io/badge/AppVersion-3.14.0-informational?style=flat-square)
 
 A Helm chart for KubeRocketCI Platform
 
@@ -10,7 +10,7 @@ A Helm chart for KubeRocketCI Platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.13.5 |
+| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.14.0 |
 
 ## Values
 
@@ -22,6 +22,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.cd-pipeline-operator.secretManager | string | `"own"` | Flag indicating whether the operator should manage secrets for stages. This parameter controls the provisioning of the 'regcred' secret within deployed environments, facilitating access to private container registries. Set the parameter to "none" under the following conditions:   - If 'global.dockerRegistry.type=ecr' and IRSA is enabled, or   - If 'global.dockerRegistry.type=openshift'. For private registries, choose the most appropriate method to provide credentials to deployed environments. Refer to the guide for managing container registries (https://docs.kuberocketci.io/docs/user-guide/manage-container-registries). Possible values: own/eso/none.   - own: Copies the secret once from the parent namespace, without subsequent reconciliation. If updated in the parent namespace, manual updating in all created namespaces is required.   - eso: The secret will be managed by the External Secrets Operator (requires installation and configuration in the cluster: https://docs.kuberocketci.io/docs/operator-guide/secrets-management/install-external-secrets-operator).   - none: Disables secrets management logic. |
 | edp-install.cd-pipeline-operator.tenancyEngine | string | `"none"` | Defines the type of the tenant engine that can be "none", "kiosk" or "capsule"; for Stages with external cluster tenancyEngine will be ignored. Default: none |
 | edp-install.codebase-operator.enabled | bool | `true` |  |
+| edp-install.codebase-operator.ingressController | string | `"nginx"` | Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute). When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}. |
 | edp-install.edp-headlamp.config.baseURL | string | `""` | base url path at which headlamp should run |
 | edp-install.edp-headlamp.config.oidc | object | `{"clientID":"shared","clientSecretKey":"clientSecret","clientSecretName":"keycloak-client-headlamp-secret","enabled":false,"issuerUrl":"","scopes":""}` | For detailed instructions, refer to: https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks, https://docs.kuberocketci.io/docs/operator-guide/auth/ui-portal-oidc |
 | edp-install.edp-headlamp.config.oidc.clientID | string | `"shared"` | OIDC client ID |
@@ -30,6 +31,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.edp-headlamp.config.oidc.issuerUrl | string | `""` | Azure Entra: https://sts.windows.net/<tenant-id>/ |
 | edp-install.edp-headlamp.config.oidc.scopes | string | `""` | OIDC scopes to be used |
 | edp-install.edp-headlamp.enabled | bool | `false` |  |
+| edp-install.edp-tekton.clusterName | string | `"core"` | Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...). Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard. |
 | edp-install.edp-tekton.enabled | bool | `true` |  |
 | edp-install.edp-tekton.gitServers | object | `{}` |  |
 | edp-install.edp-tekton.interceptor.enabled | bool | `true` | Deploy KubeRocketCI interceptor as a part of pipeline library when true. Default: true |
@@ -52,8 +54,11 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.global.apiClusterEndpoint | string | `""` | API Сluster Endpoint configuration for static kubeconfig generation |
 | edp-install.global.apiGatewayUrl | string | `""` | API Gateway URL configuration for Widget Functionality |
 | edp-install.global.availableClusters | string | `""` | Define the list of available remote clusters to deploy applications. Example: "cluster1, cluster2, cluster3" |
+| edp-install.global.clusterName | string | `"core"` | Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...). Must match krci-portal configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of dnsWildCard |
 | edp-install.global.developerGroupName | string | `""` |  |
 | edp-install.global.dnsWildCard | string | `"example.com"` | a cluster DNS wildcard name |
+| edp-install.global.gatewayApi.gatewayName | string | `"main-gateway"` | Name of the parent Gateway resource |
+| edp-install.global.gatewayApi.gatewayNamespace | string | `"envoy-gateway-system"` | Namespace of the parent Gateway resource |
 | edp-install.global.gitProviders | string | `nil` | Can be gerrit, github or gitlab. By default: github |
 | edp-install.global.platform | string | `"kubernetes"` | platform type that can be "kubernetes" or "openshift" |
 | edp-install.global.viewerGroupName | string | `""` |  |

--- a/clusters/core/addons/kuberocketci/values.yaml
+++ b/clusters/core/addons/kuberocketci/values.yaml
@@ -1,11 +1,14 @@
 edp-install:
 ## edp-install configuration
-## Full list of parameters are available in https://github.com/epam/edp-install/blob/v3.13.5/deploy-templates/values.yaml and in each of subchart
+## Full list of parameters are available in https://github.com/epam/edp-install/blob/v3.14.0/deploy-templates/values.yaml and in each of subchart
   global:
      # -- platform type that can be "kubernetes" or "openshift"
     platform: "kubernetes"
     # -- a cluster DNS wildcard name
     dnsWildCard: example.com
+    # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
+    # Must match krci-portal configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of dnsWildCard
+    clusterName: "core"
     # Specifies the URL of the API Gateway used by widgets in the platform.
     # The 'apiGatewayUrl' should be set to the external URL of the KrakenD API Gateway exposed via Ingress.
     # Example: https://api.domain.example.com
@@ -32,6 +35,24 @@ edp-install:
       # - gitlab
       # - gerrit
       # - bitbucket
+
+    # Gateway API parent Gateway that EventListener/webhook HTTPRoutes attach to.
+    # Shared by edp-tekton and codebase-operator; the Gateway itself must already exist
+    # (provisioned by Envoy Gateway, e.g. via edp-cluster-add-ons).
+    #
+    # Switching from nginx Ingress to Envoy Gateway (safe, per-gitServer, reversible):
+    #   1. Keep the default here (main-gateway/envoy-gateway-system) or point at your Gateway.
+    #   2. Per gitServer, set edp-tekton.gitServers.<name>.eventListener.httproute.enabled=true.
+    #      The Ingress stays rendered as a fallback, so the webhook keeps working during cutover.
+    #   3. Set codebase-operator.ingressController=envoy so the operator registers new webhooks
+    #      against the HTTPRoute host instead of the Ingress host.
+    #   4. Once traffic is confirmed on Envoy, set eventListener.ingress.enabled=false to drop nginx.
+    # These values are ignored while ingressController=nginx and no gitServer enables httproute.
+    gatewayApi:
+      # -- Name of the parent Gateway resource
+      gatewayName: "main-gateway"
+      # -- Namespace of the parent Gateway resource
+      gatewayNamespace: "envoy-gateway-system"
 
     # Below is an example of endpoint values for each registry type:
     # type:      | url
@@ -84,6 +105,9 @@ edp-install:
 
   codebase-operator:
     enabled: true
+    # -- Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute).
+    # When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}.
+    ingressController: "nginx"
     # -- Labels to be added to the pod.
     # podLabels: {}
     # image:
@@ -187,6 +211,9 @@ edp-install:
 
   edp-tekton:
     enabled: true
+    # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
+    # Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard.
+    clusterName: "core"
 
     pipelines:
       image:


### PR DESCRIPTION
## Description

Upgrade the KubeRocketCI (`edp-install`) add-on on the core reference cluster from **3.13.5 → 3.14.0**, keeping the reference add-on and its documented values in sync with the latest release. Consumers of this reference now pull 3.14.0 and can discover its new configuration surface.

edp-install 3.14.0 pulls: codebase-operator `2.34.0`, cd-pipeline-operator `2.31.0`, edp-tekton `0.25.0`, krci-portal `0.6.0`, gitfusion `0.6.0`.

The new 3.14.0 knobs are added as commented/default examples only — **behavior is unchanged**: Envoy Gateway stays off, `codebase-operator.ingressController: nginx`, and `global.clusterName` matches the existing `krci-portal.configEnv.DEFAULT_CLUSTER_NAME`. Two of the release's five features (Envoy resources in the view-RBAC aggregation, developer-role Tekton/Triggers permissions) are chart-template changes and require no values.

Ref: EPMDEDP-17194 · Release: https://github.com/epam/edp-install/releases/tag/v3.14.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

- `helm dependency build` resolves `edp-install 3.14.0` from `https://epam.github.io/edp-helm-charts/stable` (chart present in the index).
- `helm template` renders cleanly with the new defaults; no behavioral diff vs 3.13.5 (Envoy off, nginx path unchanged).
- Expected Argo CD diff on the core cluster: `edp-install` 3.13.5 → 3.14.0 and its component images move to the 3.14.0 line; no Envoy Gateway objects are created (default-off).

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

N/A — configuration-only change.

## Additional context

The Envoy Gateway values are inert reference templates; actual per-cluster Envoy enablement (nginx → Envoy migration) is handled separately and is not activated by this PR.