### PR TITLE
EPMDEDP-17221: chore: align Tekton stack to Pipelines 1.6 LTS and latest components

### DIFF
--- a/clusters/core/addons/tekton/README.md
+++ b/clusters/core/addons/tekton/README.md
@@ -1,6 +1,6 @@
 # Tekton Results — PostgreSQL Performance Indexes
 
-Tekton Results (v0.17.2) stores PipelineRun/TaskRun data in PostgreSQL via GORM auto-migration.
+Tekton Results (v0.19.0) stores PipelineRun/TaskRun data in PostgreSQL via GORM auto-migration.
 The default schema has no indexes beyond primary keys, causing sequential scans on high-traffic query paths.
 
 ## Indexes

--- a/clusters/core/addons/tekton/chains.yaml
+++ b/clusters/core/addons/tekton/chains.yaml
@@ -40,6 +40,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-chains
+
 data:
   artifacts.taskrun.format: slsa/v1
   artifacts.taskrun.storage: "oci"
@@ -63,8 +64,8 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-chains
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.28.1"
+    version: "v0.28.1"
 spec:
   replicas: 1
   selector:
@@ -84,8 +85,8 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/part-of: tekton-chains
         # # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.27.0"
-        version: "v0.27.0"
+        pipeline.tekton.dev/release: "v0.28.1"
+        version: "v0.28.1"
     spec:
       affinity:
         nodeAffinity:
@@ -110,7 +111,14 @@ spec:
       serviceAccountName: tekton-chains-controller
       containers:
         - name: tekton-chains-controller
-          image: ghcr.io/tektoncd/chains/github.com/tektoncd/chains/cmd/controller:v0.27.0@sha256:a92aa5ba9e05aef7da224a208d79d6fb321fac943836905a894b0c1a25796eb3
+          image: ghcr.io/tektoncd/chains/github.com/tektoncd/chains/cmd/controller:v0.28.1@sha256:193e6cca677f47e800acc790705394739415ca0dd78a6b30818d5c3bb3f0be77
+          resources:
+            requests:
+              cpu: 20m
+              memory: 60Mi
+            limits:
+              cpu: 50m
+              memory: 192Mi
           volumeMounts:
             - name: signing-secrets
               mountPath: /etc/signing-secrets
@@ -138,13 +146,6 @@ spec:
             # User 65532 is the distroless nonroot user ID
             runAsUser: 65532
             runAsGroup: 65532
-          resources:
-            requests:
-              cpu: 20m
-              memory: 60Mi
-            limits:
-              cpu: 50m
-              memory: 192Mi
       volumes:
         - name: signing-secrets
           secret:
@@ -210,13 +211,15 @@ rules:
     # Controller needs cluster access to all of the CRDs that it is responsible for
     # managing.
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions", "runs"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns",
+      "pipelineresources", "conditions", "runs"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns/finalizers", "pipelineruns/finalizers", "runs/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status", "runs/status"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status",
+      "pipelineruns/status", "pipelineresources/status", "runs/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 kind: ClusterRole
@@ -371,7 +374,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace, we can still access
   # this ConfigMap.
-  version: "v0.27.0"
+  version: "v0.28.1"
 
 ---
 # Copyright 2023 Tekton Authors LLC

--- a/clusters/core/addons/tekton/interceptors.yaml
+++ b/clusters/core/addons/tekton/interceptors.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: interceptors
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 # The data is populated at install time.
 
 ---
@@ -49,10 +49,10 @@ metadata:
     app.kubernetes.io/name: core-interceptors
     app.kubernetes.io/component: interceptors
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 spec:
   replicas: 1
   selector:
@@ -67,17 +67,17 @@ spec:
         app.kubernetes.io/name: core-interceptors
         app.kubernetes.io/component: interceptors
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.35.0"
+        app.kubernetes.io/version: "v0.36.0"
         app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-core-interceptors
-        triggers.tekton.dev/release: "v0.35.0"
+        triggers.tekton.dev/release: "v0.36.0"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-        version: "v0.35.0"
+        version: "v0.36.0"
     spec:
       serviceAccountName: tekton-triggers-core-interceptors
       containers:
         - name: tekton-triggers-core-interceptors
-          image: "ghcr.io/tektoncd/triggers/interceptors-3176d6a3f314c3655b30bfd36e421dd5:v0.35.0@sha256:5666d72e68d9138fc1919a6758ea990424aa17c27c34e53bc69bcfb81ad121ea"
+          image: "ghcr.io/tektoncd/triggers/interceptors-3176d6a3f314c3655b30bfd36e421dd5:v0.36.0@sha256:35e9444ce57aed35f378b18d75e71483d81c41dc7fb6bf44119c5730d617ce54"
           ports:
             - containerPort: 8443
           args: ["-logtostderr", "-stderrthreshold", "INFO"]
@@ -127,11 +127,11 @@ metadata:
     app.kubernetes.io/name: tekton-triggers-core-interceptors
     app.kubernetes.io/component: interceptors
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
     app: tekton-triggers-core-interceptors
-    version: "v0.35.0"
+    version: "v0.36.0"
   name: tekton-triggers-core-interceptors
   namespace: tekton-pipelines
 spec:

--- a/clusters/core/addons/tekton/pipelines.yaml
+++ b/clusters/core/addons/tekton/pipelines.yaml
@@ -583,8 +583,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1419,8 +1419,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -2994,8 +2994,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -8675,8 +8675,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -9794,8 +9794,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -17116,8 +17116,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -24126,8 +24126,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
-    version: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
+    version: "v1.6.2"
 spec:
   group: tekton.dev
   versions:
@@ -24270,7 +24270,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
 # The data is populated at install time.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -24281,7 +24281,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -24300,7 +24300,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -24319,7 +24319,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -24830,7 +24830,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v1.6.1"
+  version: "v1.6.2"
 
 ---
 # Copyright 2020 Tekton Authors LLC
@@ -25295,12 +25295,12 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.6.1"
+    version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -25315,13 +25315,13 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v1.6.1"
+        pipeline.tekton.dev/release: "v1.6.2"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-controller
-        version: "v1.6.1"
+        version: "v1.6.2"
     spec:
       affinity:
         nodeAffinity:
@@ -25346,11 +25346,11 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
         - name: tekton-pipelines-controller
-          image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.6.1@sha256:0cf6d3a56cc145671dfbb74657e7ecfe90bcef9997aac0b2a122f14aa45822e6
+          image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.6.2@sha256:0025d893f75744feb6a3e99995ddd1ae7c37ecbe12e626013fe9587ba120fadc
           args: [
             # These images are built on-demand by `ko resolve` and are replaced
             # by image references by digest.
-            "-entrypoint-image", "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.6.1@sha256:4d9d1d66eef91a04e97d9222f7584508c6ea37587e8b30a8c34501d478448801", "-nop-image", "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.6.1@sha256:dfd5044855553f0a477413f3eb9aefd920df9eeb6031415cba3778c4323aec38", "-sidecarlogresults-image", "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.6.1@sha256:8c371464c177aa670fdb35b89be5343a7d60628393d3fce5df5baf94abd5341a", "-workingdirinit-image", "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.6.1@sha256:b4f4e2d44df8a65e7d0d28d1516ccd34880690a303505e429c957286dfa1a746",
+            "-entrypoint-image", "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.6.2@sha256:74f4c5014e1c6f7e1a2f678f661593c48aa9dbc3470592e862f17fc3ef88f118", "-nop-image", "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.6.2@sha256:773de14d7f55f08a372296cf5fd834cfc4cc17dd05e62ce9210cdd47d67d3708", "-sidecarlogresults-image", "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.6.2@sha256:23459a7cd4b8c62cfec4971047ed1ffc380ffccb852177bd591ec4bc3bd3e63c", "-workingdirinit-image", "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.6.2@sha256:55b151aacb56a7329c727f49450ca7d7717eb624d82cd95dabcb6f1884f24d60",
             # The shell image must allow root in order to create directories and copy files to PVCs.
             # cgr.dev/chainguard/busybox as of April 14 2022
             # image shall not contains tag, so it will be supported on a runtime like cri-o
@@ -25441,13 +25441,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v1.6.1"
+    version: "v1.6.2"
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:
@@ -25491,12 +25491,12 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.6.1"
+    version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -25511,13 +25511,13 @@ spec:
         app.kubernetes.io/name: events
         app.kubernetes.io/component: events
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v1.6.1"
+        pipeline.tekton.dev/release: "v1.6.2"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-events-controller
-        version: "v1.6.1"
+        version: "v1.6.2"
     spec:
       affinity:
         nodeAffinity:
@@ -25531,7 +25531,7 @@ spec:
       serviceAccountName: tekton-events-controller
       containers:
         - name: tekton-events-controller
-          image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.6.1@sha256:dacc4af0d4a26da5cbd712dbd78847fc30efe6c49a02938d06ad9f9b59422116
+          image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.6.2@sha256:47124a2717f64d1af4ada6b2e7758c06d615b52bd16c5d79396425db7b74dee8
           args: []
           volumeMounts:
             - name: config-logging
@@ -25610,13 +25610,13 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-events-controller
-    version: "v1.6.1"
+    version: "v1.6.2"
   name: tekton-events-controller
   namespace: tekton-pipelines
 spec:
@@ -26268,12 +26268,12 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.6.1"
+    version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -26288,13 +26288,13 @@ spec:
         app.kubernetes.io/name: resolvers
         app.kubernetes.io/component: resolvers
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v1.6.1"
+        pipeline.tekton.dev/release: "v1.6.2"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-resolvers
-        version: "v1.6.1"
+        version: "v1.6.2"
     spec:
       affinity:
         nodeAffinity:
@@ -26319,7 +26319,7 @@ spec:
       serviceAccountName: tekton-pipelines-resolvers
       containers:
         - name: controller
-          image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.6.1@sha256:38453317345ce4d09474b428649ea5005eca246eacffca835ddc34670aef0078
+          image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.6.2@sha256:d5b3551480e741e540ff0027eb327c92a95b1904ab7ade05133ee4a427cfddab
           command:
             - /sbin/tini
             - --
@@ -26405,13 +26405,13 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-remote-resolvers
-    version: "v1.6.1"
+    version: "v1.6.2"
   name: tekton-pipelines-remote-resolvers
   namespace: tekton-pipelines-resolvers
 spec:
@@ -26455,12 +26455,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.6.1"
+    version: "v1.6.2"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -26503,12 +26503,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.6.1"
+    version: "v1.6.2"
 spec:
   selector:
     matchLabels:
@@ -26522,13 +26522,13 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v1.6.1"
+        pipeline.tekton.dev/release: "v1.6.2"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-webhook
-        version: "v1.6.1"
+        version: "v1.6.2"
     spec:
       affinity:
         nodeAffinity:
@@ -26555,7 +26555,7 @@ spec:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.6.1@sha256:58749047766f4a81d75a473c8255daeaed25f59d38ef225863f6033fc2296bf7
+          image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.6.2@sha256:0d277fbb6580ca21a11eef445b2debe472c2c59c8cac835b97b424b73f1ff825
           # Resource request required for autoscaler to take any action for a metric
           resources:
             requests:
@@ -26652,13 +26652,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.6.1"
+    pipeline.tekton.dev/release: "v1.6.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v1.6.1"
+    version: "v1.6.2"
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:

--- a/clusters/core/addons/tekton/results.yaml
+++ b/clusters/core/addons/tekton/results.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api
   namespace: tekton-pipelines
 ---
@@ -12,7 +12,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 ---
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-info
   namespace: tekton-pipelines
 rules:
@@ -41,7 +41,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: tekton-results-admin
 rules:
@@ -63,7 +63,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api
 rules:
   - apiGroups:
@@ -84,7 +84,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-results-readonly
@@ -105,7 +105,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-readwrite
 rules:
   - apiGroups:
@@ -125,7 +125,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-watcher
 rules:
   - apiGroups:
@@ -143,6 +143,7 @@ rules:
     resources:
       - pipelineruns
       - taskruns
+      - customruns
     verbs:
       - get
       - list
@@ -203,7 +204,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-info
   namespace: tekton-pipelines
 roleRef:
@@ -220,7 +221,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -236,7 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-watcher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,7 +311,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api-config
   namespace: tekton-pipelines
 ---
@@ -350,7 +351,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-leader-election
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-config-leader-election
   namespace: tekton-pipelines
 ---
@@ -383,19 +384,18 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-logging
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-config-logging
   namespace: tekton-pipelines
 ---
 apiVersion: v1
 data:
-  _example: |
+  _example: |-
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
     #                              #
     ################################
-
     # This block is not actually functional configuration,
     # but serves to illustrate the available configuration
     # options and document them in a way that is accessible
@@ -404,34 +404,28 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
-
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using Stackdriver will incur additional charges.
-    metrics.backend-destination: prometheus
-
-    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used and metrics will be sent to the cluster's project if this field is
-    # not provided.
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
-
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
-    # to send metrics to Stackdriver using "global" resource type and custom
-    # metric type. Setting this flag to "true" could cause extra Stackdriver
-    # charge.  If metrics.backend-destination is not Stackdriver, this is
-    # ignored.
-    metrics.allow-stackdriver-custom-metrics: "false"
-    metrics.taskrun.level: "task"
-    metrics.taskrun.duration-type: "histogram"
-    metrics.pipelinerun.level: "pipeline"
-    metrics.pipelinerun.duration-type: "histogram"
+    #
+    # metrics-protocol specifies the OpenTelemetry export protocol.
+    # Supported values: prometheus (default), grpc, http/protobuf, none.
+    #
+    metrics-protocol: prometheus
+    #
+    # metrics-endpoint is the OTLP collector endpoint to send metrics to.
+    # Required when metrics-protocol is grpc or http/protobuf.
+    #
+    metrics-endpoint: "otel-collector.observability.svc.cluster.local:4317"
+    #
+    # metrics-export-interval is the interval at which metrics are exported.
+    # Uses Go duration format (e.g. 30s, 1m). Defaults to 30s.
+    #
+    metrics-export-interval: 30s
+  metrics-protocol: prometheus
 kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/name: tekton-results-observability
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-config-observability
   namespace: tekton-pipelines
 ---
@@ -444,19 +438,19 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-retention-policy
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-config-results-retention-policy
   namespace: tekton-pipelines
 ---
 apiVersion: v1
 data:
-  version: v0.18.0
+  version: v0.19.0
 kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-info
   namespace: tekton-pipelines
 ---
@@ -466,7 +460,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api-service
   namespace: tekton-pipelines
 spec:
@@ -485,7 +479,7 @@ spec:
       targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
 ---
 apiVersion: v1
 kind: Service
@@ -493,7 +487,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 spec:
@@ -504,7 +498,7 @@ spec:
       port: 8008
   selector:
     app.kubernetes.io/name: tekton-results-watcher
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -512,7 +506,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-api
   namespace: tekton-pipelines
 spec:
@@ -528,7 +522,7 @@ spec:
       labels:
         app: tekton-results-api
         app.kubernetes.io/name: tekton-results-api
-        app.kubernetes.io/version: v0.18.0
+        app.kubernetes.io/version: v0.19.0
     spec:
       affinity:
         nodeAffinity:
@@ -545,7 +539,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: tekton-results-api
-                    app.kubernetes.io/version: v0.18.0
+                    app.kubernetes.io/version: v0.19.0
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -560,7 +554,7 @@ spec:
                 secretKeyRef:
                   key: password
                   name: results-pguser-results
-          image: ghcr.io/tektoncd/results/api-b1b7ffa9ba32f7c3020c3b68830b30a8:v0.18.0@sha256:72833d31749615fe45d4f7b7a3d4964e5da1cc2966e983fd31f67720d5c22720
+          image: ghcr.io/tektoncd/results/api-b1b7ffa9ba32f7c3020c3b68830b30a8:v0.19.0@sha256:aae3d01eb3ff05cf4a476c7c14ed54d9240361cc9f62bc428239de84e3f61390
           livenessProbe:
             httpGet:
               path: /healthz
@@ -627,7 +621,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-retention-policy-agent
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-retention-policy-agent
   namespace: tekton-pipelines
 spec:
@@ -643,7 +637,7 @@ spec:
       labels:
         app: tekton-results-retention-policy-agent
         app.kubernetes.io/name: tekton-results-retention-policy-agent
-        app.kubernetes.io/version: v0.18.0
+        app.kubernetes.io/version: v0.19.0
     spec:
       containers:
         - env:
@@ -663,7 +657,7 @@ spec:
                 secretKeyRef:
                   key: password
                   name: results-pguser-results
-          image: ghcr.io/tektoncd/results/retention-policy-agent-07427b345034d96a9a27896ebb138518:v0.18.0@sha256:b523e3d2bc70fbf8089b8b5ee42b506ccd335f10c633e7f975ec0d250e0d2aea
+          image: ghcr.io/tektoncd/results/retention-policy-agent-07427b345034d96a9a27896ebb138518:v0.19.0@sha256:64c2aa521a10bc4465453d5b51ed2d3f0b9b4f5d560ba6ebde24af18b27af37f
           name: retention-policy-agent
           securityContext:
             allowPrivilegeEscalation: false
@@ -697,7 +691,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 spec:
@@ -713,7 +707,7 @@ spec:
       labels:
         app: tekton-results-watcher
         app.kubernetes.io/name: tekton-results-watcher
-        app.kubernetes.io/version: v0.18.0
+        app.kubernetes.io/version: v0.19.0
     spec:
       affinity:
         nodeAffinity:
@@ -730,7 +724,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: tekton-results-watcher
-                    app.kubernetes.io/version: v0.18.0
+                    app.kubernetes.io/version: v0.19.0
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -762,7 +756,7 @@ spec:
               value: insecure
             - name: KUBERNETES_MIN_VERSION
               value: v1.28.0
-          image: ghcr.io/tektoncd/results/watcher-83f971ea227fb24157c0c699b824a628:v0.18.0@sha256:4b50291457cb63028e5f9e2acb921b852d9ad0f265562ea0fa83bafc8a58b367
+          image: ghcr.io/tektoncd/results/watcher-83f971ea227fb24157c0c699b824a628:v0.19.0@sha256:eb8b64d733b3611c67d442bd683d447110cd07a758e4e261ffcf63238fc25117
           name: watcher
           ports:
             - containerPort: 9090

--- a/clusters/core/addons/tekton/triggers.yaml
+++ b/clusters/core/addons/tekton/triggers.yaml
@@ -398,8 +398,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Cluster
@@ -454,8 +454,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Cluster
@@ -524,8 +524,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
@@ -630,8 +630,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
@@ -686,8 +686,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
@@ -758,8 +758,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
@@ -832,8 +832,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
-    version: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
+    version: "v0.36.0"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
@@ -908,7 +908,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 # The data is populated at install time.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -919,7 +919,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -939,7 +939,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -959,7 +959,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -1167,7 +1167,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v0.35.0"
+  version: "v0.36.0"
 
 ---
 # Copyright 2023 Tekton Authors LLC
@@ -1357,6 +1357,7 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-triggers
 data:
+  metrics-protocol: prometheus
   _example: |
     ################################
     #                              #
@@ -1373,22 +1374,44 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
-    metrics.backend-destination: prometheus
+    # OpenTelemetry Metrics Configuration
+    # Protocol for metrics export (prometheus, grpc, http/protobuf, none)
+    # Default if not specified: "none"
+    metrics-protocol: prometheus
 
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used if this field is not provided.
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    # Metrics endpoint (for grpc/http protocols)
+    # Default: empty (uses default OTLP endpoint)
+    metrics-endpoint: ""
 
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
-    # Stackdriver using "global" resource type and custom metric type if the
-    # metrics are not supported by "knative_revision" resource type. Setting this
-    # flag to "true" could cause extra Stackdriver charge.
-    # If metrics.backend-destination is not Stackdriver, this is ignored.
-    metrics.allow-stackdriver-custom-metrics: "false"
+    # Metrics export interval (e.g., "30s", "1m")
+    # Default: empty (uses default interval)
+    metrics-export-interval: ""
+
+    # OpenTelemetry Tracing Configuration
+    # Protocol for tracing export (grpc, http/protobuf, none, stdout)
+    # Default: none
+    tracing-protocol: none
+
+    # Tracing endpoint (for grpc/http protocols)
+    # Default: empty
+    tracing-endpoint: ""
+
+    # Tracing sampling rate (0.0 to 1.0)
+    # Default: 0.0 (no sampling)
+    tracing-sampling-rate: "0.0"
+
+    # Runtime Configuration
+    # Enable profiling (enabled, disabled)
+    # Default: disabled
+    runtime-profiling: disabled
+
+    # Runtime export interval (e.g., "15s")
+    # Default: 15s
+    runtime-export-interval: "15s"
+
+    # Note: Legacy OpenCensus configuration (metrics.backend-destination, etc.)
+    # has been removed. OpenCensus is no longer supported. Please use the
+    # OpenTelemetry configuration options above.
 
 ---
 # Copyright 2019 Tekton Authors LLC
@@ -1412,11 +1435,11 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
     app: tekton-triggers-controller
-    version: "v0.35.0"
+    version: "v0.36.0"
   name: tekton-triggers-controller
   namespace: tekton-pipelines
 spec:
@@ -1455,10 +1478,10 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 spec:
   replicas: 1
   selector:
@@ -1473,12 +1496,12 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.35.0"
+        app.kubernetes.io/version: "v0.36.0"
         app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-controller
-        triggers.tekton.dev/release: "v0.35.0"
+        triggers.tekton.dev/release: "v0.36.0"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-        version: "v0.35.0"
+        version: "v0.36.0"
     spec:
       affinity:
         nodeAffinity:
@@ -1503,8 +1526,8 @@ spec:
       serviceAccountName: tekton-triggers-controller
       containers:
         - name: tekton-triggers-controller
-          image: "ghcr.io/tektoncd/triggers/controller-f656ca31de179ab913fa76abc255c315:v0.35.0@sha256:59addf5899cd2cf1e74001ddf7ad30e0492b8c80b80857c351e2deac545d9555"
-          args: ["-logtostderr", "-stderrthreshold", "INFO", "-el-image", "ghcr.io/tektoncd/triggers/eventlistenersink-7ad1faa98cddbcb0c24990303b220bb8:v0.35.0@sha256:d4ddfc09a5389474452644826540973a53fea11be718abf7ab3d04159c29ed05", "-el-port", "8080", "-el-security-context=true", "-el-read-only-root-filesystem=true", "-el-events", "disable", "-el-readtimeout", "5", "-el-writetimeout", "40", "-el-idletimeout", "120", "-el-timeouthandler", "30", "-el-httpclient-readtimeout", "30", "-el-httpclient-keep-alive", "30", "-el-httpclient-tlshandshaketimeout", "10", "-el-httpclient-responseheadertimeout", "10", "-el-httpclient-expectcontinuetimeout", "1", "-period-seconds", "10", "-failure-threshold", "3"]
+          image: "ghcr.io/tektoncd/triggers/controller-f656ca31de179ab913fa76abc255c315:v0.36.0@sha256:03f192f4aebeb3471db9d390d0532ab4d49e5aeeb70327df91be445f3629e859"
+          args: ["-logtostderr", "-stderrthreshold", "INFO", "-el-image", "ghcr.io/tektoncd/triggers/eventlistenersink-7ad1faa98cddbcb0c24990303b220bb8:v0.36.0@sha256:ca044dc8b45cb5f5089faf553b4cbd5f0f8e05fcf8d66db7a703c88a40163a73", "-el-port", "8080", "-el-security-context=true", "-el-read-only-root-filesystem=true", "-el-events", "disable", "-el-readtimeout", "5", "-el-writetimeout", "40", "-el-idletimeout", "120", "-el-timeouthandler", "30", "-el-httpclient-readtimeout", "30", "-el-httpclient-keep-alive", "30", "-el-httpclient-tlshandshaketimeout", "10", "-el-httpclient-responseheadertimeout", "10", "-el-httpclient-expectcontinuetimeout", "1", "-period-seconds", "10", "-failure-threshold", "3"]
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -1561,11 +1584,11 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
     app: tekton-triggers-webhook
-    version: "v0.35.0"
-    triggers.tekton.dev/release: "v0.35.0"
+    version: "v0.36.0"
+    triggers.tekton.dev/release: "v0.36.0"
 spec:
   ports:
     - name: https-webhook
@@ -1601,10 +1624,10 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.35.0"
+    app.kubernetes.io/version: "v0.36.0"
     app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-    triggers.tekton.dev/release: "v0.35.0"
+    triggers.tekton.dev/release: "v0.36.0"
 spec:
   replicas: 1
   selector:
@@ -1619,19 +1642,19 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.35.0"
+        app.kubernetes.io/version: "v0.36.0"
         app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-webhook
-        triggers.tekton.dev/release: "v0.35.0"
+        triggers.tekton.dev/release: "v0.36.0"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-        version: "v0.35.0"
+        version: "v0.36.0"
     spec:
       serviceAccountName: tekton-triggers-webhook
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: "ghcr.io/tektoncd/triggers/webhook-dd1edc925ee1772a9f76e2c1bc291ef6:v0.35.0@sha256:bc97fb4dd2e55b5723e3f2ee7c5a9a5beea4a1362c0a4b2fa40a2cf638cbd9c7"
+          image: "ghcr.io/tektoncd/triggers/webhook-dd1edc925ee1772a9f76e2c1bc291ef6:v0.36.0@sha256:02d25a89d4b58e7cf341ea32c44d4938eaa3a43b6eafb61d88b9abb0d8a6f67d"
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:


### PR DESCRIPTION


Upgrade the tekton addon manifests:
- Pipelines v1.6.1 -> v1.6.2, picking up HIGH git-resolver CVE fixes (CVE-2026-40161, CVE-2026-40938); custom default-pod-template preserved
- Triggers/Interceptors v0.35.0 -> v0.36.0
- Chains v0.27.0 -> v0.28.1 (includes CVE-2026-48702 fix); custom chains-config and controller resources re-applied
- Results v0.18.0 -> v0.19.0 with customruns RBAC and OTel observability config; external PGO database and logs PVC customizations preserved

