### PR TITLE
EPMDEDP-17228: feat: add argocd-diff-preview addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 |:-----------------------------|:----------|:-------------|:-----------------------|:------------------|:---------|
 | argo-cd                      | 9.5.13    | v3.4.1       | krci                   | False             | False    |
 | argo-events                  | 2.4.23    | v1.9.11      | argo-events            | True              | False    |
+| argocd-diff-preview          | 0.1.0     | 0.35.1       | argocd-diff-preview    | True              | False    |
 | atlantis                     | 6.6.0     | v0.44.0      | atlantis               | False             | False    |
 | aws-efs-csi-driver           | 3.2.2     | 2.1.11       | kube-system            | N/A               | False    |
 | awx-operator                 | 2.19.1    | 2.19.1       | awx-operator           | False             | False    |

--- a/clusters/core/addons/argocd-diff-preview/Chart.yaml
+++ b/clusters/core/addons/argocd-diff-preview/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+description: >-
+  Argo CD Diff Preview environment for GitOps review pipelines: a standing
+  vcluster with a minimal Argo CD inside, used by the argocd-diff-preview
+  step of the gitops review pipelines to render manifest diffs for merge
+  requests. Installing this addon activates the diff preview feature; the
+  pipeline step skips silently when the addon is absent.
+home: https://docs.kuberocketci.io/
+name: argocd-diff-preview
+type: application
+version: 0.1.0
+appVersion: 0.35.1
+
+dependencies:
+- name: vcluster
+  version: 0.35.1
+  repository: https://charts.loft.sh

--- a/clusters/core/addons/argocd-diff-preview/README.md
+++ b/clusters/core/addons/argocd-diff-preview/README.md
@@ -1,0 +1,69 @@
+# argocd-diff-preview
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.35.1](https://img.shields.io/badge/AppVersion-0.35.1-informational?style=flat-square)
+
+**Homepage:** <https://docs.kuberocketci.io/>
+
+Deploys a standing [vcluster](https://www.vcluster.com/) with a minimal
+[Argo CD](https://argo-cd.readthedocs.io/) bootstrapped inside. The
+`argocd-diff-preview` step of the KubeRocketCI gitops review pipelines connects
+to this environment to render the manifest diff between a merge request and its
+target branch, and posts the result as an MR comment.
+
+**Installing this addon is the feature's on-switch.** The pipeline step is
+always present and best-effort: when the addon is absent or unhealthy, the step
+skips silently and the review pipeline stays green.
+
+## How it works
+
+1. The pipeline step reads the `vc-argocd-diff-preview` kubeconfig secret from this
+   addon's namespace and connects to the virtual cluster.
+2. Application manifests exported from the platform namespace are applied to
+   the embedded Argo CD, with `targetRevision` redirected to the MR head SHA
+   (target) and the MR target branch (base).
+3. The embedded Argo CD clones the GitOps repository itself over SSH - the
+   platform repo-creds secret is projected into the virtual cluster via
+   vcluster `sync.fromHost.secrets`, so rotation propagates automatically. The
+   syncer's read RBAC is derived from the mapping keys, so adding a mapping
+   automatically grants the required access.
+4. The rendered manifests of both revisions are diffed and the result is
+   posted to the merge request.
+
+## Site-specific configuration
+
+- **Git server host keys**: add them to the embedded Argo CD via
+  `configs.ssh.extraHosts` in the bootstrap chart values when the git server is
+  not covered by the default `known_hosts` bundle.
+- **DNS**: the git server hostname must resolve from cluster workloads. For
+  environments where it does not (e.g. the try-kuberocketci testbed's
+  `127.0.0.1.nip.io` domain), ship a CoreDNS override via
+  `vcluster.experimental.deploy.vcluster.manifests`.
+- Keep `vcluster.exportKubeConfig.server` and `controlPlane.proxy.extraSANs`
+  aligned with the release name and namespace.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.loft.sh | vcluster | 0.35.1 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| vcluster.controlPlane.proxy.extraSANs[0] | string | `"argocd-diff-preview.argocd-diff-preview.svc"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].chart.name | string | `"argo-cd"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].chart.repo | string | `"https://argoproj.github.io/argo-helm"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].chart.version | string | `"9.5.17"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].release.name | string | `"argocd"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].release.namespace | string | `"argocd"` |  |
+| vcluster.experimental.deploy.vcluster.helm[0].values | string | `"dex:\n  enabled: false\nnotifications:\n  enabled: false\nconfigs:\n  params:\n    server.insecure: true"` |  |
+| vcluster.experimental.deploy.vcluster.manifests | string | `""` |  |
+| vcluster.exportKubeConfig.server | string | `"https://argocd-diff-preview.argocd-diff-preview.svc:443"` |  |
+| vcluster.rbac.clusterRole.enabled | bool | `false` |  |
+| vcluster.sync.fromHost.csiDrivers.enabled | bool | `false` |  |
+| vcluster.sync.fromHost.csiNodes.enabled | bool | `false` |  |
+| vcluster.sync.fromHost.csiStorageCapacities.enabled | bool | `false` |  |
+| vcluster.sync.fromHost.secrets.enabled | bool | `true` |  |
+| vcluster.sync.fromHost.secrets.mappings.byName.argocd/gitlab-creds | string | `"argocd/gitlab-creds"` |  |
+| vcluster.sync.fromHost.storageClasses.enabled | bool | `false` |  |

--- a/clusters/core/addons/argocd-diff-preview/README.md.gotmpl
+++ b/clusters/core/addons/argocd-diff-preview/README.md.gotmpl
@@ -1,0 +1,49 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+Deploys a standing [vcluster](https://www.vcluster.com/) with a minimal
+[Argo CD](https://argo-cd.readthedocs.io/) bootstrapped inside. The
+`argocd-diff-preview` step of the KubeRocketCI gitops review pipelines connects
+to this environment to render the manifest diff between a merge request and its
+target branch, and posts the result as an MR comment.
+
+**Installing this addon is the feature's on-switch.** The pipeline step is
+always present and best-effort: when the addon is absent or unhealthy, the step
+skips silently and the review pipeline stays green.
+
+## How it works
+
+1. The pipeline step reads the `vc-argocd-diff-preview` kubeconfig secret from this
+   addon's namespace and connects to the virtual cluster.
+2. Application manifests exported from the platform namespace are applied to
+   the embedded Argo CD, with `targetRevision` redirected to the MR head SHA
+   (target) and the MR target branch (base).
+3. The embedded Argo CD clones the GitOps repository itself over SSH - the
+   platform repo-creds secret is projected into the virtual cluster via
+   vcluster `sync.fromHost.secrets`, so rotation propagates automatically. The
+   syncer's read RBAC is derived from the mapping keys, so adding a mapping
+   automatically grants the required access.
+4. The rendered manifests of both revisions are diffed and the result is
+   posted to the merge request.
+
+## Site-specific configuration
+
+- **Git server host keys**: add them to the embedded Argo CD via
+  `configs.ssh.extraHosts` in the bootstrap chart values when the git server is
+  not covered by the default `known_hosts` bundle.
+- **DNS**: the git server hostname must resolve from cluster workloads. For
+  environments where it does not (e.g. the try-kuberocketci testbed's
+  `127.0.0.1.nip.io` domain), ship a CoreDNS override via
+  `vcluster.experimental.deploy.vcluster.manifests`.
+- Keep `vcluster.exportKubeConfig.server` and `controlPlane.proxy.extraSANs`
+  aligned with the release name and namespace.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/clusters/core/addons/argocd-diff-preview/templates/fromhost-secrets-rbac.yaml
+++ b/clusters/core/addons/argocd-diff-preview/templates/fromhost-secrets-rbac.yaml
@@ -1,0 +1,42 @@
+{{- /*
+The vcluster syncer projects platform secrets into the virtual cluster
+(sync.fromHost.secrets). Its ServiceAccount is namespace-scoped
+(rbac.clusterRole.enabled=false), so it needs explicit read access in every
+host namespace referenced by the mappings. The namespaces are derived from the
+mapping keys ("<host-namespace>/<name>") so the RBAC can never drift from the
+sync configuration. list/watch cannot be limited by resourceName - these roles
+are intentionally read-only.
+*/ -}}
+{{- $namespaces := dict }}
+{{- range $key, $_ := (((((.Values.vcluster).sync).fromHost).secrets).mappings).byName }}
+  {{- $ns := (splitList "/" $key) | first }}
+  {{- if $ns }}
+    {{- $_ := set $namespaces $ns true }}
+  {{- end }}
+{{- end }}
+{{- range $ns, $_ := $namespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Release.Name }}-fromhost-secrets
+  namespace: {{ $ns }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Release.Name }}-fromhost-secrets
+  namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Release.Name }}-fromhost-secrets
+subjects:
+  - kind: ServiceAccount
+    name: vc-{{ $.Release.Name }}
+    namespace: {{ $.Release.Namespace }}
+---
+{{- end }}

--- a/clusters/core/addons/argocd-diff-preview/values.yaml
+++ b/clusters/core/addons/argocd-diff-preview/values.yaml
@@ -1,0 +1,107 @@
+vcluster:
+  # The gitops review pipeline reads this secret to connect; keep the release
+  # name and namespace aligned with the server URL and SAN below.
+  exportKubeConfig:
+    server: https://argocd-diff-preview.argocd-diff-preview.svc:443
+
+  controlPlane:
+    proxy:
+      extraSANs:
+        - argocd-diff-preview.argocd-diff-preview.svc
+
+  # Namespace-scoped RBAC only: the preview environment needs no nodes,
+  # storage classes or CSI objects from the host.
+  rbac:
+    clusterRole:
+      enabled: false
+
+  sync:
+    fromHost:
+      storageClasses:
+        enabled: false
+      csiNodes:
+        enabled: false
+      csiDrivers:
+        enabled: false
+      csiStorageCapacities:
+        enabled: false
+      # Project the platform repo-creds secret into the virtual cluster so the
+      # embedded Argo CD clones the GitOps repository with the same credentials
+      # as the platform - nothing is copied at runtime and rotation propagates
+      # automatically. The addon derives read RBAC for the syncer from these
+      # mapping keys (see templates/fromhost-secrets-rbac.yaml).
+      secrets:
+        enabled: true
+        mappings:
+          byName:
+            # host-namespace/name: vcluster-namespace/name
+            "argocd/gitlab-creds": "argocd/gitlab-creds"
+            #
+            # Argo CD matches credentials per source repoURL: 'repository'
+            # secrets by exact URL, 'repo-creds' secrets by URL prefix - one
+            # prefix template usually covers a whole git server, so the number
+            # of mappings scales with git servers, not repositories. Add one
+            # mapping per credential secret the preview needs:
+            # "argocd/github-org-creds": "argocd/github-org-creds"
+            # "argocd/oci-registry-creds": "argocd/oci-registry-creds"
+            #
+            # If the platform keeps repository credentials in a dedicated
+            # namespace (e.g. materialized there by External Secrets), project
+            # them wholesale - new credentials then flow in with no addon
+            # changes. Read RBAC for that namespace is derived automatically:
+            # "argocd-repo-creds/*": "argocd/*"
+            #
+            # Avoid "argocd/*": it would project admin, cluster and TLS
+            # secrets into the preview environment.
+
+  experimental:
+    deploy:
+      vcluster:
+        # Optional raw manifests applied inside the virtual cluster at boot.
+        # Used on environments whose git host is not resolvable from pods
+        # (e.g. the try-kuberocketci testbed's 127.0.0.1.nip.io domain needs a
+        # CoreDNS forward to the host cluster DNS). Empty by default:
+        # production git hosts must simply be resolvable from cluster
+        # workloads.
+        #
+        # Example - forward a loopback nip.io git host to the host cluster DNS
+        # (10.96.0.10 = host kube-dns ClusterIP):
+        # manifests: |
+        #   apiVersion: v1
+        #   kind: ConfigMap
+        #   metadata:
+        #     name: coredns-custom
+        #     namespace: kube-system
+        #   data:
+        #     gitlab.server: |
+        #       gitlab.127.0.0.1.nip.io:1053 {
+        #           forward . 10.96.0.10
+        #       }
+        manifests: ""
+        helm:
+          - chart:
+              name: argo-cd
+              repo: https://argoproj.github.io/argo-helm
+              version: 9.5.17
+            release:
+              name: argocd
+              namespace: argocd
+            # Minimal Argo CD: it only renders manifests, it never syncs.
+            # configs.ssh.extraHosts must carry the git server host keys when
+            # the server is not covered by the chart's default known_hosts
+            # (one entry per self-hosted SSH git server; obtain via
+            # 'ssh-keyscan -p <port> <host>'). Example:
+            #
+            # configs:
+            #   ssh:
+            #     extraHosts: |
+            #       [gitlab.example.com]:32222 ssh-ed25519 AAAA...
+            #       [gitlab.example.com]:32222 ssh-rsa AAAA...
+            values: |-
+              dex:
+                enabled: false
+              notifications:
+                enabled: false
+              configs:
+                params:
+                  server.insecure: true

--- a/clusters/core/apps/README.md
+++ b/clusters/core/apps/README.md
@@ -25,6 +25,9 @@ EDP Cluster Addons that extend the Kubernetes Cluster Functionality
 | argo-cd.createNamespace | bool | `false` | whether to create the namespace or not |
 | argo-events | object | `{"createNamespace":true,"enable":false,"namespace":"argo-events"}` | Argo Events — KubeRocketCI notification bus (Tekton CloudEvents -> EventBus -> Sensors) |
 | argoProject | string | `"core"` |  |
+| argocd-diff-preview.createNamespace | bool | `true` |  |
+| argocd-diff-preview.enable | bool | `false` |  |
+| argocd-diff-preview.namespace | string | `"argocd-diff-preview"` |  |
 | atlantis.createNamespace | bool | `false` |  |
 | atlantis.enable | bool | `false` |  |
 | atlantis.namespace | string | `"atlantis"` |  |

--- a/clusters/core/apps/templates/argocd-diff-preview.yaml
+++ b/clusters/core/apps/templates/argocd-diff-preview.yaml
@@ -1,0 +1,29 @@
+{{- if and (index .Values "argocd-diff-preview") (index .Values "argocd-diff-preview" "enable") -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.destinationServer}}-argocd-diff-preview
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.argoProject | default "default" }}
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: clusters/{{ .Values.clusterName }}/addons/argocd-diff-preview
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      releaseName: argocd-diff-preview
+  destination:
+    name: {{ .Values.destinationServer | default "in-cluster" }}
+    namespace: {{ index .Values "argocd-diff-preview" "namespace" }}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace={{ index .Values "argocd-diff-preview" "createNamespace" }}
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+{{- end -}}

--- a/clusters/core/apps/values.yaml
+++ b/clusters/core/apps/values.yaml
@@ -31,6 +31,14 @@ argo-events:
   enable: false
   namespace: argo-events
 
+# Argo CD Diff Preview environment for the GitOps review pipelines.
+# Installing this addon activates MR diff previews; the pipeline step skips
+# silently when the addon is absent.
+argocd-diff-preview:
+  createNamespace: true
+  enable: false
+  namespace: argocd-diff-preview
+
 atlantis:
   createNamespace: false
   enable: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -27,6 +27,7 @@ chart-repos:
   - external-secrets=https://charts.external-secrets.io
   - fluent=https://fluent.github.io/helm-charts
   - gitlab=https://charts.gitlab.io
+  - loft=https://charts.loft.sh
   - goharbor=https://helm.goharbor.io
   - grafana=https://grafana.github.io/helm-charts
   - hashicorp=https://helm.releases.hashicorp.com


### PR DESCRIPTION
Standing vcluster with an embedded minimal Argo CD used by the GitOps review pipelines to render MR manifest diffs. Installing the addon activates the feature; the pipeline step skips silently when the addon is absent.

- vcluster exports its kubeconfig at a stable in-cluster address
- embedded Argo CD is bootstrapped via vcluster experimental.deploy
- platform repo-creds are projected via sync.fromHost.secrets; syncer read RBAC is derived from the mapping keys (single source of truth)
- registered in the core App-of-Apps (disabled by default)

