### PR TITLE
EPMDEDP-17194: chore: Upgrade KubeRocketCI addon to 3.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | krci-events                  | 0.1.0     | 0.1.0        | argo-events            | False             | False    |
 | kuberocketci-pipelines       | N/A       | N/A          | krci                   | False             | False    |
 | kuberocketci-rbac            | 0.1.0     | 0.1.0        | krci-security          | False             | False    |
-| kuberocketci                 | 3.14.0    | 3.14.0       | krci                   | False             | False    |
+| kuberocketci                 | 3.14.1    | 3.14.1       | krci                   | False             | False    |
 | minio-operator               | 7.1.1     | v7.1.1       | minio-operator         | False             | False    |
 | moon                         | 2.7.11    | 2.7.11       | moon                   | False             | False    |
 | nexus-ce                     | 0.1.1     | 3.82.0       | nexus                  | False             | False    |

--- a/clusters/core/addons/kuberocketci/Chart.yaml
+++ b/clusters/core/addons/kuberocketci/Chart.yaml
@@ -3,10 +3,10 @@ description: A Helm chart for KubeRocketCI Platform
 home: https://docs.kuberocketci.io/
 name: edp-install
 type: application
-version: 3.14.0
-appVersion: 3.14.0
+version: 3.14.1
+appVersion: 3.14.1
 
 dependencies:
 - name: edp-install
-  version: 3.14.0
+  version: 3.14.1
   repository: https://epam.github.io/edp-helm-charts/stable

--- a/clusters/core/addons/kuberocketci/README.md
+++ b/clusters/core/addons/kuberocketci/README.md
@@ -1,6 +1,6 @@
 # edp-install
 
-![Version: 3.14.0](https://img.shields.io/badge/Version-3.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.0](https://img.shields.io/badge/AppVersion-3.14.0-informational?style=flat-square)
+![Version: 3.14.1](https://img.shields.io/badge/Version-3.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.1](https://img.shields.io/badge/AppVersion-3.14.1-informational?style=flat-square)
 
 A Helm chart for KubeRocketCI Platform
 
@@ -10,7 +10,7 @@ A Helm chart for KubeRocketCI Platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.14.0 |
+| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.14.1 |
 
 ## Values
 
@@ -21,6 +21,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.cd-pipeline-operator.manageNamespace | bool | `true` | should the operator manage(create/delete) namespaces for stages Refer to the guide for managing namespace (https://docs.kuberocketci.io/docs/operator-guide/auth/namespace-management) |
 | edp-install.cd-pipeline-operator.secretManager | string | `"own"` | Flag indicating whether the operator should manage secrets for stages. This parameter controls the provisioning of the 'regcred' secret within deployed environments, facilitating access to private container registries. Set the parameter to "none" under the following conditions:   - If 'global.dockerRegistry.type=ecr' and IRSA is enabled, or   - If 'global.dockerRegistry.type=openshift'. For private registries, choose the most appropriate method to provide credentials to deployed environments. Refer to the guide for managing container registries (https://docs.kuberocketci.io/docs/user-guide/manage-container-registries). Possible values: own/eso/none.   - own: Copies the secret once from the parent namespace, without subsequent reconciliation. If updated in the parent namespace, manual updating in all created namespaces is required.   - eso: The secret will be managed by the External Secrets Operator (requires installation and configuration in the cluster: https://docs.kuberocketci.io/docs/operator-guide/secrets-management/install-external-secrets-operator).   - none: Disables secrets management logic. |
 | edp-install.cd-pipeline-operator.tenancyEngine | string | `"none"` | Defines the type of the tenant engine that can be "none", "kiosk" or "capsule"; for Stages with external cluster tenancyEngine will be ignored. Default: none |
+| edp-install.codebase-operator.branchStaleCheckInterval | string | `"24h"` | How often the operator re-checks that codebase branches still exist in git, marking missing ones with the Stale condition and the app.edp.epam.com/stale label (portal shows a stale badge). |
 | edp-install.codebase-operator.enabled | bool | `true` |  |
 | edp-install.codebase-operator.ingressController | string | `"nginx"` | Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute). When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}. |
 | edp-install.edp-headlamp.config.baseURL | string | `""` | base url path at which headlamp should run |
@@ -35,8 +36,13 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.edp-tekton.enabled | bool | `true` |  |
 | edp-install.edp-tekton.gitServers | object | `{}` |  |
 | edp-install.edp-tekton.interceptor.enabled | bool | `true` | Deploy KubeRocketCI interceptor as a part of pipeline library when true. Default: true |
+| edp-install.edp-tekton.pipelines.cancelInProgress | bool | `false` | Cancel in-progress review PipelineRuns when a new commit is pushed to the same Pull Request / Merge Request / Gerrit change. Handled by the KRCI interceptor (no extra components); cancellation is graceful, so finally tasks of the superseded run still execute. |
 | edp-install.edp-tekton.pipelines.image.registry | string | `"docker.io"` | Registry for tekton pipelines images. Default: docker.io |
 | edp-install.edp-tekton.pipelines.imagePullSecrets | list | `[]` | List of image pull secrets used by the Tekton ServiceAccount for pulling images from private registries. Example: imagePullSecrets:   - name: regcred |
+| edp-install.edp-tekton.portalHost | string | `""` | Host used to build krci-portal pipeline links in Tekton (and Reporter PR comments), together with clusterName. If empty, falls back to a value derived from global.dnsWildCard. |
+| edp-install.edp-tekton.reporter.commentStrategy | string | `"update"` | Report comment strategy: 'update' edits the previous report comment of the same pull request, 'new' always creates a new comment |
+| edp-install.edp-tekton.reporter.enabled | bool | `true` | Deploy the Tekton Reporter as a part of the pipeline library when true. Default: true |
+| edp-install.edp-tekton.reporter.tailLines | int | `100` | Number of trailing log lines published for every failed step |
 | edp-install.edp-tekton.tekton-cache.enabled | bool | `true` |  |
 | edp-install.edp-tekton.tekton.pruner.create | bool | `true` |  |
 | edp-install.externalSecrets.enabled | bool | `false` | Configure External Secrets for KubeRocketCI platform. Deploy SecretStore. Default: false |

--- a/clusters/core/addons/kuberocketci/values.yaml
+++ b/clusters/core/addons/kuberocketci/values.yaml
@@ -1,6 +1,6 @@
 edp-install:
 ## edp-install configuration
-## Full list of parameters are available in https://github.com/epam/edp-install/blob/v3.14.0/deploy-templates/values.yaml and in each of subchart
+## Full list of parameters are available in https://github.com/epam/edp-install/blob/v3.14.1/deploy-templates/values.yaml and in each of subchart
   global:
      # -- platform type that can be "kubernetes" or "openshift"
     platform: "kubernetes"
@@ -108,6 +108,9 @@ edp-install:
     # -- Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute).
     # When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}.
     ingressController: "nginx"
+    # -- How often the operator re-checks that codebase branches still exist in git, marking
+    # missing ones with the Stale condition and the app.edp.epam.com/stale label (portal shows a stale badge).
+    branchStaleCheckInterval: 24h
     # -- Labels to be added to the pod.
     # podLabels: {}
     # image:
@@ -214,8 +217,16 @@ edp-install:
     # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
     # Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard.
     clusterName: "core"
+    # -- Host used to build krci-portal pipeline links in Tekton (and Reporter PR comments), together with clusterName.
+    # If empty, falls back to a value derived from global.dnsWildCard.
+    portalHost: ""
 
     pipelines:
+      # -- Cancel in-progress review PipelineRuns when a new commit is pushed to the same
+      # Pull Request / Merge Request / Gerrit change. Handled by the KRCI interceptor (no extra
+      # components); cancellation is graceful, so finally tasks of the superseded run still execute.
+      cancelInProgress: false
+
       image:
         # -- Registry for tekton pipelines images. Default: docker.io
         registry: "docker.io"
@@ -244,6 +255,18 @@ edp-install:
       ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry
       # imagePullSecrets: []
       # - name: regcred
+
+    # The Tekton Reporter publishes a pull request comment with the per-task status table and the
+    # trailing logs of failed steps for finished review PipelineRuns. Links use portalHost + clusterName.
+    # SECURITY: published logs come from steps that execute the PR's own code; secret masking is
+    # best-effort, not a hard boundary - only enable where secret-bearing steps don't run untrusted code.
+    reporter:
+      # -- Deploy the Tekton Reporter as a part of the pipeline library when true. Default: true
+      enabled: true
+      # -- Number of trailing log lines published for every failed step
+      tailLines: 100
+      # -- Report comment strategy: 'update' edits the previous report comment of the same pull request, 'new' always creates a new comment
+      commentStrategy: update
 
     # GitServers configuration section
     # GitServer creation depends on the gitProviders configuration, if gitProvider is not enabled,


### PR DESCRIPTION
## Description
Routine bump of the `kuberocketci` add-on (edp-install umbrella chart) from 3.14.0
to the 3.14.1 patch release (edp-install "Update current development version").
Transitively pulls edp-tekton 0.26.0 and krci-portal 0.7.0; no add-on values changes
(the Envoy Gateway / clusterName template introduced in 3.14.0 is unchanged).

## Type of change
- [x] Improvement

## How Has This Been Tested?
- Compared edp-install Chart.yaml between v3.14.0 and v3.14.1: only edp-tekton
  (0.25.0→0.26.0) and krci-portal (0.6.0→0.7.0) pins changed.
- Verified the add-on is a pure version-string bump (no new values keys), so README
  values table is unchanged; only version badges + dependency version updated.

## Checklist
- [x] Self-review performed
- [x] Corresponding documentation (README badges/table) updated
- [x] No new warnings
- [x] Single squashed commit