### PR TITLE
EPMDEDP-17136: feat: add nginx-fallback catch-all HTTPRoute to ingres…

### DIFF
--- a/clusters/core/addons/ingress-nginx/README.md
+++ b/clusters/core/addons/ingress-nginx/README.md
@@ -44,4 +44,9 @@ A Helm chart for Nginx Ingress Controller
 | ingress-nginx.serviceAccount.name | string | `"nginx-ingress-service-account"` |  |
 | ingress-nginx.updateStrategy.rollingUpdate.maxUnavailable | int | `1` |  |
 | ingress-nginx.updateStrategy.type | string | `"RollingUpdate"` |  |
+| nginxFallback.enabled | bool | `false` | Enable the nginx-fallback catch-all HTTPRoute. |
+| nginxFallback.gateway.name | string | `"main-gateway"` | Name of the parent Gateway the fallback route attaches to. |
+| nginxFallback.gateway.namespace | string | `"envoy-gateway-system"` | Namespace of the parent Gateway. |
+| nginxFallback.service.name | string | `"ingress-nginx-controller"` | nginx-ingress controller Service the fallback route forwards unmatched traffic to. |
+| nginxFallback.service.port | int | `80` | Port on the nginx-ingress controller Service. |
 

--- a/clusters/core/addons/ingress-nginx/templates/httproute-nginx-fallback.yaml
+++ b/clusters/core/addons/ingress-nginx/templates/httproute-nginx-fallback.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.nginxFallback.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nginx-fallback
+spec:
+  parentRefs:
+    - name: {{ .Values.nginxFallback.gateway.name }}
+      namespace: {{ .Values.nginxFallback.gateway.namespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.nginxFallback.service.name }}
+          port: {{ .Values.nginxFallback.service.port }}
+{{- end }}

--- a/clusters/core/addons/ingress-nginx/values.yaml
+++ b/clusters/core/addons/ingress-nginx/values.yaml
@@ -55,3 +55,25 @@ ingress-nginx:
   serviceAccount:
     create: true
     name: nginx-ingress-service-account
+
+# Catch-all HTTPRoute that forwards any request Envoy Gateway can't match to a more
+# specific HTTPRoute back to the nginx-ingress controller. Having no hostnames, it sits
+# at the lowest Gateway API precedence and can never shadow a real HTTPRoute, so it lets
+# Envoy Gateway become the ALB default target group without a per-host allow-list.
+# Disabled by default (opt-in): additive and inert until the cluster runs Envoy Gateway
+# and the ALB default action is flipped to Envoy (platform_default_gateway in
+# terraform-aws-platform). Requires the parent Gateway below to exist — provided by the
+# envoy-gateway-resources add-on.
+nginxFallback:
+  # -- Enable the nginx-fallback catch-all HTTPRoute.
+  enabled: false
+  gateway:
+    # -- Name of the parent Gateway the fallback route attaches to.
+    name: main-gateway
+    # -- Namespace of the parent Gateway.
+    namespace: envoy-gateway-system
+  service:
+    # -- nginx-ingress controller Service the fallback route forwards unmatched traffic to.
+    name: ingress-nginx-controller
+    # -- Port on the nginx-ingress controller Service.
+    port: 80


### PR DESCRIPTION
## Description

Adds an optional **catch-all `HTTPRoute` (`nginx-fallback`)** to the `ingress-nginx` add-on.

This is part of migrating the platform edge from nginx-ingress to **Envoy Gateway**. Once
Envoy Gateway fronts the cluster, only hosts that have an explicit `HTTPRoute` are served by
Envoy directly. Every other host — i.e. everything still on a plain `Ingress` — would have
nowhere to go. This route closes that gap: having **no `hostnames`**, it is the
lowest-precedence route on the shared Gateway, so it matches only what nothing else matched
and forwards it straight back to the nginx-ingress controller, which then does its usual
`Ingress` routing.

The effect is a single, dynamic fallback path — `Envoy Gateway → nginx-fallback → nginx-ingress
→ Ingress` — that lets each host be cut over to a native Envoy `HTTPRoute` **one at a time**,
with no big-bang switch and no per-host ALB rules. Until a host gets its own route, it keeps
working through nginx exactly as before.

How it works:

- `kind: HTTPRoute` (`gateway.networking.k8s.io/v1`) attached via `parentRefs` to the shared
  Gateway (`main-gateway` / `envoy-gateway-system` by default).
- **No `hostnames`** → in Gateway API this is the weakest match, so it can never shadow a
  real, hostname-scoped `HTTPRoute`. Any specific route always wins; this one only ever
  serves the remainder.
- A single rule matching `PathPrefix: /` with a `backendRef` to the nginx-ingress controller
  Service (`ingress-nginx-controller:80` by default).

Disabled by default (`nginxFallback.enabled: false`) — it is opt-in, since not every consumer
of this chart runs Envoy Gateway, and enabling it without a parent Gateway would create an
orphaned route. The Gateway name/namespace and the backend Service name/port are all
configurable via values.

Tracking: EPMDEDP-17136 (nginx-ingress → Envoy Gateway migration).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Static rendering and linting of the chart:

```bash
# 1. Disabled by default -> renders nothing (inert for clusters that don't opt in)
helm template ingress-nginx clusters/core/addons/ingress-nginx \
  | grep -c 'kind: HTTPRoute'

# 2. Enabled -> renders the catch-all with the expected shape
helm template ingress-nginx clusters/core/addons/ingress-nginx \
  --set nginxFallback.enabled=true \
  --show-only templates/httproute-nginx-fallback.yaml
#   -> HTTPRoute, no hostnames, parentRef main-gateway/envoy-gateway-system,
#      PathPrefix / -> ingress-nginx-controller:80

# 3. Parent Gateway is configurable
helm template ... --set nginxFallback.enabled=true \
  --set nginxFallback.gateway.name=edge-gateway \
  --set nginxFallback.gateway.namespace=custom-gw \
  --show-only templates/httproute-nginx-fallback.yaml
#   -> parentRefs: [{ name: edge-gateway

# 4. Backend Service is configurable
helm template ... --set nginxFallback.en
  --set nginxFallback.service.name=my-nginx \
  --set nginxFallback.service.port=8080 \
  --show-only templates/httproute-nginx-fallback.yaml
#   -> backendRefs: [{ name: my-nginx, port: 8080 }]

# 5. Rendered manifest is valid YAML wite (parsed + asserted)
# 6. helm lint -> 1 chart(s) linted, 0 chart(s) failed
# 7. helm-docs re-run produces no diff vs the committed README (docs in sync)
```

## Checklist:

- [x] I have performed a self-review of
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

N/A

## Additional context

- The route is purely additive: on clusters that don't set `nginxFallback.enabled=true`,
  nothing is rendered and behavior is un
- This chart change is independent of, and safe to merge ahead of, the ALB edge cutover
  (see the companion change in `terraform-aws-platform`, `EPMDEDP-17136`). The fallback route
  must exist **before** the ALB default action is pointed at Envoy Gateway, otherwise hosts
  without an explicit `HTTPRoute` would have no backend.