### PR TITLE
EPMDEDP-17248: chore: drop tekton-resource-pruner references

### DIFF
--- a/clusters/core/addons/keda-tenants/templates/cd-pipeline-operator.yaml
+++ b/clusters/core/addons/keda-tenants/templates/cd-pipeline-operator.yaml
@@ -23,8 +23,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $.Values.thresholdPods }}"

--- a/clusters/core/addons/keda-tenants/templates/codebase-operator.yaml
+++ b/clusters/core/addons/keda-tenants/templates/codebase-operator.yaml
@@ -23,8 +23,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $.Values.thresholdPods }}"

--- a/clusters/core/addons/keda-tenants/templates/git-providers.yaml
+++ b/clusters/core/addons/keda-tenants/templates/git-providers.yaml
@@ -26,8 +26,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $globalValues.thresholdPods }}"

--- a/clusters/core/addons/keda-tenants/templates/krci-portal.yaml
+++ b/clusters/core/addons/keda-tenants/templates/krci-portal.yaml
@@ -23,8 +23,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $.Values.thresholdPods }}"

--- a/clusters/core/addons/keda-tenants/templates/portal.yaml
+++ b/clusters/core/addons/keda-tenants/templates/portal.yaml
@@ -23,8 +23,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $.Values.thresholdPods }}"

--- a/clusters/core/addons/keda-tenants/templates/tekton-interceptor.yaml
+++ b/clusters/core/addons/keda-tenants/templates/tekton-interceptor.yaml
@@ -23,8 +23,7 @@ spec:
         query: |
           count(
             kube_pod_created{
-              namespace="{{ $namespace }}",
-              pod!~"tekton-resource-pruner.*"
+              namespace="{{ $namespace }}"
             } > time() - {{ $timeInterval }}
           ) or vector(0)
         threshold: "{{ $.Values.thresholdPods }}"

--- a/clusters/core/addons/kuberocketci/README.md
+++ b/clusters/core/addons/kuberocketci/README.md
@@ -44,7 +44,6 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.edp-tekton.reporter.enabled | bool | `true` | Deploy the Tekton Reporter as a part of the pipeline library when true. Default: true |
 | edp-install.edp-tekton.reporter.tailLines | int | `100` | Number of trailing log lines published for every failed step |
 | edp-install.edp-tekton.tekton-cache.enabled | bool | `true` |  |
-| edp-install.edp-tekton.tekton.pruner.create | bool | `true` |  |
 | edp-install.externalSecrets.enabled | bool | `false` | Configure External Secrets for KubeRocketCI platform. Deploy SecretStore. Default: false |
 | edp-install.externalSecrets.manageEDPInstallSecrets | bool | `true` | Create necessary secrets for KubeRocketCI installation, using External Secret Operator |
 | edp-install.externalSecrets.manageEDPInstallSecretsName | string | `"/edp/deploy-secrets"` | Value name in AWS ParameterStore or AWS SecretsManager. Used when manageEDPInstallSecrets is true |

--- a/clusters/core/addons/kuberocketci/values.yaml
+++ b/clusters/core/addons/kuberocketci/values.yaml
@@ -242,12 +242,6 @@ edp-install:
       # Tekton cache endpoint for pipeline-library helm chart. See charts/pipelines-library/templates/resources/cm-tekton-cache.yaml
       # url: http://tekton-cache:8080
 
-    tekton:
-      pruner:
-        create: true
-        # -- List of ImagePullSecrets to be used by the pruner CronJob
-        # imagePullSecrets: []
-
     interceptor:
       # -- Deploy KubeRocketCI interceptor as a part of pipeline library when true. Default: true
       enabled: true


### PR DESCRIPTION
The pruner CronJob has been removed from the edp-tekton chart now that Tekton Results owns retention and cleanup of completed PipelineRuns.

The KEDA tenant scalers excluded the pruner from their pod-creation queries so its hourly job pods would not hold a tenant awake; with the CronJob gone the exclusion matches nothing. The kuberocketci add-on also carried a tekton.pruner override that no longer exists in the umbrella chart.

