### PR TITLE
EPMDEDP-17198: feat: upgrade Keycloak to 26.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | karpenter                    | 1.8.4     | 1.8.4        | karpenter              | False             | False    |
 | keda-tenants                 | 0.1.2     | 0.1.0        | keda                   | False             | False    |
 | keda                         | 2.17.2    | 2.17.2       | keda                   | False             | False    |
-| keycloak                     | 2.3.0     | 24.0.4       | security               | False             | False    |
+| keycloak                     | 3.0.0     | 26.6.4       | security               | False             | False    |
 | keycloak-postgresql          | 0.1.1     | 1.0          | security               | False             | False    |
 | keycloak-operator            | 1.34.0    | 1.34.0       | keycloak-operator      | False             | False    |
 | krakend                      | 0.1.36    | 2.7.2        | krci-krakend           | False             | False    |

--- a/clusters/core/addons/keycloak/Chart.yaml
+++ b/clusters/core/addons/keycloak/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.0
+version: 3.0.0
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "24.0.4"
+appVersion: "26.6.4"
 
 dependencies:
 - name: keycloakx
-  version: 2.3.0
+  version: 7.2.2
   repository: https://codecentric.github.io/helm-charts

--- a/clusters/core/addons/keycloak/README.md
+++ b/clusters/core/addons/keycloak/README.md
@@ -1,6 +1,6 @@
 # keycloak
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.0.4](https://img.shields.io/badge/AppVersion-24.0.4-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.6.4](https://img.shields.io/badge/AppVersion-26.6.4-informational?style=flat-square)
 
 A Helm chart for Keycloak
 
@@ -74,7 +74,7 @@ To expose internal Keycloak endpoint, follow the steps below:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://codecentric.github.io/helm-charts | keycloakx | 2.3.0 |
+| https://codecentric.github.io/helm-charts | keycloakx | 7.2.2 |
 
 ## Values
 
@@ -113,11 +113,11 @@ To expose internal Keycloak endpoint, follow the steps below:
 | keycloakx.database.username | string | `"admin"` |  |
 | keycloakx.database.vendor | string | `"postgres"` |  |
 | keycloakx.dbchecker.enabled | bool | `true` |  |
-| keycloakx.extraEnv | string | `"- name: KC_HOSTNAME\n  value: \"idp.example.com\"\n- name: KC_SPI_HOSTNAME_DEFAULT_ADMIN\n  value: \"idp.example.com\"\n- name: KC_HTTP_ENABLED\n  value: \"true\"\n- name: KC_HOSTNAME_STRICT\n  value: \"false\"\n- name: KC_HOSTNAME_STRICT_HTTPS\n  value: \"false\"\n- name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL\n  value: \"info\"\n- name: KEYCLOAK_ADMIN\n  valueFrom:\n    secretKeyRef:\n      name: keycloak-admin-creds\n      key: username\n- name: KEYCLOAK_ADMIN_PASSWORD\n  valueFrom:\n    secretKeyRef:\n      name: keycloak-admin-creds\n      key: password\n- name: JAVA_OPTS_APPEND\n  value: >-\n    -XX:+UseContainerSupport\n    -XX:MaxRAMPercentage=50.0\n    -Djava.awt.headless=true\n    -Djgroups.dns.query={{ include \"keycloak.fullname\" . }}-headless\n    -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true\n    -Dkeycloak.connectionsHttpClient.default.reuse-connections=false\n- name: HTTP_ADDRESS_FORWARDING\n  value: \"true\"\n- name: PROXY_ADDRESS_FORWARDING\n  value: \"true\"\n"` |  |
+| keycloakx.extraEnv | string | `"# Both hostnames expect a full URL, not a bare host. Keep the scheme when\n# substituting your own domain.\n- name: KC_HOSTNAME\n  value: \"https://idp.example.com\"\n- name: KC_HOSTNAME_ADMIN\n  value: \"https://idp.example.com\"\n- name: KC_HOSTNAME_STRICT\n  value: \"false\"\n- name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL\n  value: \"info\"\n# Keycloak's outbound pool never expires idle connections, so the identity provider callback\n# can reuse one the network path already closed and fail with Connection reset. Expire them\n# after 30s, which still covers the token, userinfo and JWKS calls of a single callback.\n- name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_CONNECTION_TTL_MILLIS\n  value: \"30000\"\n- name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_MAX_CONNECTION_IDLE_TIME_MILLIS\n  value: \"30000\"\n# Credentials of the temporary admin created on first startup only.\n- name: KC_BOOTSTRAP_ADMIN_USERNAME\n  valueFrom:\n    secretKeyRef:\n      name: keycloak-admin-creds\n      key: username\n- name: KC_BOOTSTRAP_ADMIN_PASSWORD\n  valueFrom:\n    secretKeyRef:\n      name: keycloak-admin-creds\n      key: password\n"` |  |
 | keycloakx.fullnameOverride | string | `"keycloakx"` |  |
 | keycloakx.health.enabled | bool | `false` |  |
 | keycloakx.http.relativePath | string | `"/"` |  |
-| keycloakx.image.tag | string | `"24.0.4"` |  |
+| keycloakx.image.tag | string | `"26.6.4"` |  |
 | keycloakx.ingress.annotations."nginx.ingress.kubernetes.io/proxy-buffer-size" | string | `"256k"` |  |
 | keycloakx.ingress.console.annotations | string | `nil` |  |
 | keycloakx.ingress.console.enabled | bool | `true` |  |
@@ -139,7 +139,8 @@ To expose internal Keycloak endpoint, follow the steps below:
 | keycloakx.metrics.enabled | bool | `false` |  |
 | keycloakx.nameOverride | string | `"keycloakx"` |  |
 | keycloakx.proxy.enabled | bool | `true` |  |
-| keycloakx.proxy.mode | string | `"edge"` |  |
+| keycloakx.proxy.http.enabled | bool | `true` |  |
+| keycloakx.proxy.mode | string | `"xforwarded"` |  |
 | keycloakx.replicas | int | `1` |  |
 | keycloakx.resources.limits.memory | string | `"2048Mi"` |  |
 | keycloakx.resources.requests.cpu | string | `"50m"` |  |

--- a/clusters/core/addons/keycloak/values.yaml
+++ b/clusters/core/addons/keycloak/values.yaml
@@ -4,7 +4,7 @@ keycloakx:
   replicas: 1
 
   image:
-    tag: "24.0.4"
+    tag: "26.6.4"
 
   # The following parameter is unrecommended to expose. Exposed health checks lead to an unnecessary attack vector.
   health:
@@ -22,48 +22,42 @@ keycloakx:
     relativePath: "/"
 
   # Additional environment variables for Keycloak.
-  # Environment variables "KC_HOSTNAME ADMIN_URL" and "KC_HOSTNAME URL" for working in "passthrough" mode,
-  # if they are not defined there will be an eternal loading of "LOGIN ADMIN UI"
+  # Both KC_HOSTNAME and KC_HOSTNAME_ADMIN must be set, otherwise the Admin UI
+  # loads indefinitely when Keycloak sits behind a TLS-terminating proxy.
   extraEnv: |
+    # Both hostnames expect a full URL, not a bare host. Keep the scheme when
+    # substituting your own domain.
     - name: KC_HOSTNAME
-      value: "idp.example.com"
-    - name: KC_SPI_HOSTNAME_DEFAULT_ADMIN
-      value: "idp.example.com"
-    - name: KC_HTTP_ENABLED
-      value: "true"
+      value: "https://idp.example.com"
+    - name: KC_HOSTNAME_ADMIN
+      value: "https://idp.example.com"
     - name: KC_HOSTNAME_STRICT
-      value: "false"
-    - name: KC_HOSTNAME_STRICT_HTTPS
       value: "false"
     - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL
       value: "info"
-    - name: KEYCLOAK_ADMIN
+    # Keycloak's outbound pool never expires idle connections, so the identity provider callback
+    # can reuse one the network path already closed and fail with Connection reset. Expire them
+    # after 30s, which still covers the token, userinfo and JWKS calls of a single callback.
+    - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_CONNECTION_TTL_MILLIS
+      value: "30000"
+    - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_MAX_CONNECTION_IDLE_TIME_MILLIS
+      value: "30000"
+    # Credentials of the temporary admin created on first startup only.
+    - name: KC_BOOTSTRAP_ADMIN_USERNAME
       valueFrom:
         secretKeyRef:
           name: keycloak-admin-creds
           key: username
-    - name: KEYCLOAK_ADMIN_PASSWORD
+    - name: KC_BOOTSTRAP_ADMIN_PASSWORD
       valueFrom:
         secretKeyRef:
           name: keycloak-admin-creds
           key: password
-    - name: JAVA_OPTS_APPEND
-      value: >-
-        -XX:+UseContainerSupport
-        -XX:MaxRAMPercentage=50.0
-        -Djava.awt.headless=true
-        -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
-        -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true
-        -Dkeycloak.connectionsHttpClient.default.reuse-connections=false
-    - name: HTTP_ADDRESS_FORWARDING
-      value: "true"
-    - name: PROXY_ADDRESS_FORWARDING
-      value: "true"
 
   # Example how to add custom theme to Keycloak
   # extraInitContainers: |
   #   - name: theme-provider
-  #     image: docker.io/epamedp/edp-keycloak-theme:0.1.5
+  #     image: docker.io/epamedp/edp-keycloak-theme:0.1.12
   #     imagePullPolicy: IfNotPresent
   #     command:
   #       - sh
@@ -123,8 +117,12 @@ keycloakx:
 
   proxy:
     enabled: true
-    # Ensure X-Forwarded-For header is set to the client's IP address
-    mode: "edge"
+    # Trust the X-Forwarded-* headers that nginx-ingress sends, so Keycloak sees
+    # the client's IP address and the external scheme.
+    mode: "xforwarded"
+    # TLS is terminated at the Ingress, so Keycloak serves plain HTTP internally.
+    http:
+      enabled: true
 
   resources:
     limits:


### PR DESCRIPTION
Keycloak versions prior to 26.5.3 decode organization invitation tokens without verifying their cryptographic signature, letting an attacker tamper with the org_id and eml claims to self-register into restricted organizations (CVSS 8.1).

Move the add-on from Keycloak 24.0.4 to 26.6.4 via keycloakx chart 7.2.2, which enforces signature verification before rendering registration pages.

Crossing two major versions requires the accompanying configuration migration:
- hostname v2 expects full URLs, and KC_HOSTNAME_ADMIN supersedes the removed KC_SPI_HOSTNAME_DEFAULT_ADMIN
- the bootstrap admin credentials are read from KC_BOOTSTRAP_ADMIN_USERNAME/PASSWORD, leaving the existing secret name and keys untouched
- proxy mode edge was removed, so X-Forwarded-* handling and plain internal HTTP are configured through the chart instead
- clustering and HTTP client tuning previously passed via JAVA_OPTS_APPEND are now handled by the chart, with idle connection expiry set explicitly to keep identity provider callbacks stable

The chart is bumped to 3.0.0 because these values changes are breaking for anyone overriding extraEnv or proxy settings.

