### PR TITLE
EPMDEDP-17261: chore: bump Tekton Results to v0.20.0

### DIFF
--- a/clusters/core/addons/tekton/results.yaml
+++ b/clusters/core/addons/tekton/results.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api
   namespace: tekton-pipelines
 ---
@@ -12,7 +12,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 ---
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-info
   namespace: tekton-pipelines
 rules:
@@ -41,7 +41,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: tekton-results-admin
 rules:
@@ -63,7 +63,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api
 rules:
   - apiGroups:
@@ -84,7 +84,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-results-readonly
@@ -105,7 +105,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-readwrite
 rules:
   - apiGroups:
@@ -125,7 +125,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-watcher
 rules:
   - apiGroups:
@@ -204,7 +204,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-info
   namespace: tekton-pipelines
 roleRef:
@@ -221,7 +221,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -237,7 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-watcher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -311,7 +311,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api-config
   namespace: tekton-pipelines
 ---
@@ -351,7 +351,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-leader-election
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-config-leader-election
   namespace: tekton-pipelines
 ---
@@ -384,7 +384,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-logging
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-config-logging
   namespace: tekton-pipelines
 ---
@@ -425,7 +425,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-observability
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-config-observability
   namespace: tekton-pipelines
 ---
@@ -438,19 +438,19 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-retention-policy
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-config-results-retention-policy
   namespace: tekton-pipelines
 ---
 apiVersion: v1
 data:
-  version: v0.19.0
+  version: v0.20.0
 kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/name: tekton-results-info
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-info
   namespace: tekton-pipelines
 ---
@@ -460,7 +460,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api-service
   namespace: tekton-pipelines
 spec:
@@ -479,7 +479,7 @@ spec:
       targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
 ---
 apiVersion: v1
 kind: Service
@@ -487,7 +487,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 spec:
@@ -498,7 +498,7 @@ spec:
       port: 8008
   selector:
     app.kubernetes.io/name: tekton-results-watcher
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -506,7 +506,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-api
   namespace: tekton-pipelines
 spec:
@@ -522,7 +522,7 @@ spec:
       labels:
         app: tekton-results-api
         app.kubernetes.io/name: tekton-results-api
-        app.kubernetes.io/version: v0.19.0
+        app.kubernetes.io/version: v0.20.0
     spec:
       affinity:
         nodeAffinity:
@@ -539,7 +539,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: tekton-results-api
-                    app.kubernetes.io/version: v0.19.0
+                    app.kubernetes.io/version: v0.20.0
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -554,7 +554,7 @@ spec:
                 secretKeyRef:
                   key: password
                   name: results-pguser-results
-          image: ghcr.io/tektoncd/results/api-b1b7ffa9ba32f7c3020c3b68830b30a8:v0.19.0@sha256:aae3d01eb3ff05cf4a476c7c14ed54d9240361cc9f62bc428239de84e3f61390
+          image: ghcr.io/tektoncd/results/api-b1b7ffa9ba32f7c3020c3b68830b30a8:v0.20.0@sha256:b0d55e887a79d195d9964f42c3a1dc7967fb08f5307c350ab51905f9897a34ff
           livenessProbe:
             httpGet:
               path: /healthz
@@ -621,7 +621,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-retention-policy-agent
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-retention-policy-agent
   namespace: tekton-pipelines
 spec:
@@ -637,7 +637,7 @@ spec:
       labels:
         app: tekton-results-retention-policy-agent
         app.kubernetes.io/name: tekton-results-retention-policy-agent
-        app.kubernetes.io/version: v0.19.0
+        app.kubernetes.io/version: v0.20.0
     spec:
       containers:
         - env:
@@ -657,7 +657,7 @@ spec:
                 secretKeyRef:
                   key: password
                   name: results-pguser-results
-          image: ghcr.io/tektoncd/results/retention-policy-agent-07427b345034d96a9a27896ebb138518:v0.19.0@sha256:64c2aa521a10bc4465453d5b51ed2d3f0b9b4f5d560ba6ebde24af18b27af37f
+          image: ghcr.io/tektoncd/results/retention-policy-agent-07427b345034d96a9a27896ebb138518:v0.20.0@sha256:59a1fdde49bdbc6a26e5f3e630cbb86641a1848dd25ed587678c519aa6ea0c0f
           name: retention-policy-agent
           securityContext:
             allowPrivilegeEscalation: false
@@ -691,7 +691,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/version: v0.19.0
+    app.kubernetes.io/version: v0.20.0
   name: tekton-results-watcher
   namespace: tekton-pipelines
 spec:
@@ -707,7 +707,7 @@ spec:
       labels:
         app: tekton-results-watcher
         app.kubernetes.io/name: tekton-results-watcher
-        app.kubernetes.io/version: v0.19.0
+        app.kubernetes.io/version: v0.20.0
     spec:
       affinity:
         nodeAffinity:
@@ -724,7 +724,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: tekton-results-watcher
-                    app.kubernetes.io/version: v0.19.0
+                    app.kubernetes.io/version: v0.20.0
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -756,7 +756,7 @@ spec:
               value: insecure
             - name: KUBERNETES_MIN_VERSION
               value: v1.28.0
-          image: ghcr.io/tektoncd/results/watcher-83f971ea227fb24157c0c699b824a628:v0.19.0@sha256:eb8b64d733b3611c67d442bd683d447110cd07a758e4e261ffcf63238fc25117
+          image: ghcr.io/tektoncd/results/watcher-83f971ea227fb24157c0c699b824a628:v0.20.0@sha256:a5fb2d24d5c455c62fda7ce80c36b39af1e50d482a4bfdd289f436287f3c21c9
           name: watcher
           ports:
             - containerPort: 9090


### PR DESCRIPTION
Picks up the upstream watcher fix (tektoncd/results#1285), which populates RecordSummary StartTime/EndTime from the run's status fields instead of Knative conditions that batch resources never set. Archived PipelineRuns get accurate start and completion times, which the portal history list renders as durations.

The upstream v0.19.0 -> v0.20.0 delta is limited to the three component image digests and the version labels, so only those are applied. The KRCI customizations are left untouched: CloudNativePG connection details, the summary_labels the portal depends on, log storage, and the auth settings.

