### PR TITLE
EPMDEDP-17274: chore: Bump edp-install chart to 3.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The repository provides a wide range of pre-configured add-ons for Kubernetes cl
 | krci-events                  | 0.1.0     | 0.1.0        | argo-events            | False             | False    |
 | kuberocketci-pipelines       | N/A       | N/A          | krci                   | False             | False    |
 | kuberocketci-rbac            | 0.1.0     | 0.1.0        | krci-security          | False             | False    |
-| kuberocketci                 | 3.14.1    | 3.14.1       | krci                   | False             | False    |
+| kuberocketci                 | 3.15.0    | 3.15.0       | krci                   | False             | False    |
 | minio-operator               | 7.1.1     | v7.1.1       | minio-operator         | False             | False    |
 | moon                         | 2.7.11    | 2.7.11       | moon                   | False             | False    |
 | nexus-ce                     | 0.1.1     | 3.82.0       | nexus                  | False             | False    |

--- a/clusters/core/addons/kuberocketci/Chart.yaml
+++ b/clusters/core/addons/kuberocketci/Chart.yaml
@@ -3,10 +3,10 @@ description: A Helm chart for KubeRocketCI Platform
 home: https://docs.kuberocketci.io/
 name: edp-install
 type: application
-version: 3.14.1
-appVersion: 3.14.1
+version: 3.15.0
+appVersion: 3.15.0
 
 dependencies:
 - name: edp-install
-  version: 3.14.1
+  version: 3.15.0
   repository: https://epam.github.io/edp-helm-charts/stable

--- a/clusters/core/addons/kuberocketci/README.md
+++ b/clusters/core/addons/kuberocketci/README.md
@@ -1,6 +1,6 @@
 # edp-install
 
-![Version: 3.14.1](https://img.shields.io/badge/Version-3.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.1](https://img.shields.io/badge/AppVersion-3.14.1-informational?style=flat-square)
+![Version: 3.15.0](https://img.shields.io/badge/Version-3.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.0](https://img.shields.io/badge/AppVersion-3.15.0-informational?style=flat-square)
 
 A Helm chart for KubeRocketCI Platform
 
@@ -10,7 +10,7 @@ A Helm chart for KubeRocketCI Platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.14.1 |
+| https://epam.github.io/edp-helm-charts/stable | edp-install | 3.15.0 |
 
 ## Values
 
@@ -24,14 +24,6 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.codebase-operator.branchStaleCheckInterval | string | `"24h"` | How often the operator re-checks that codebase branches still exist in git, marking missing ones with the Stale condition and the app.edp.epam.com/stale label (portal shows a stale badge). |
 | edp-install.codebase-operator.enabled | bool | `true` |  |
 | edp-install.codebase-operator.ingressController | string | `"nginx"` | Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute). When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}. |
-| edp-install.edp-headlamp.config.baseURL | string | `""` | base url path at which headlamp should run |
-| edp-install.edp-headlamp.config.oidc | object | `{"clientID":"shared","clientSecretKey":"clientSecret","clientSecretName":"keycloak-client-headlamp-secret","enabled":false,"issuerUrl":"","scopes":""}` | For detailed instructions, refer to: https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks, https://docs.kuberocketci.io/docs/operator-guide/auth/ui-portal-oidc |
-| edp-install.edp-headlamp.config.oidc.clientID | string | `"shared"` | OIDC client ID |
-| edp-install.edp-headlamp.config.oidc.clientSecretKey | string | `"clientSecret"` | OIDC client secret key |
-| edp-install.edp-headlamp.config.oidc.clientSecretName | string | `"keycloak-client-headlamp-secret"` | OIDC client secret name |
-| edp-install.edp-headlamp.config.oidc.issuerUrl | string | `""` | Azure Entra: https://sts.windows.net/<tenant-id>/ |
-| edp-install.edp-headlamp.config.oidc.scopes | string | `""` | OIDC scopes to be used |
-| edp-install.edp-headlamp.enabled | bool | `false` |  |
 | edp-install.edp-tekton.clusterName | string | `"core"` | Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...). Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard. |
 | edp-install.edp-tekton.enabled | bool | `true` |  |
 | edp-install.edp-tekton.gitServers | object | `{}` |  |
@@ -42,6 +34,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-install.edp-tekton.portalHost | string | `""` | Host used to build krci-portal pipeline links in Tekton (and Reporter PR comments), together with clusterName. If empty, falls back to a value derived from global.dnsWildCard. |
 | edp-install.edp-tekton.reporter.commentStrategy | string | `"update"` | Report comment strategy: 'update' edits the previous report comment of the same pull request, 'new' always creates a new comment |
 | edp-install.edp-tekton.reporter.enabled | bool | `true` | Deploy the Tekton Reporter as a part of the pipeline library when true. Default: true |
+| edp-install.edp-tekton.reporter.logsReporting | bool | `false` | Publish trailing log lines of failed steps in PR comments. Disabled by default to prevent secrets exposure |
 | edp-install.edp-tekton.reporter.tailLines | int | `100` | Number of trailing log lines published for every failed step |
 | edp-install.edp-tekton.tekton-cache.enabled | bool | `true` |  |
 | edp-install.externalSecrets.enabled | bool | `false` | Configure External Secrets for KubeRocketCI platform. Deploy SecretStore. Default: false |

--- a/clusters/core/addons/kuberocketci/values.yaml
+++ b/clusters/core/addons/kuberocketci/values.yaml
@@ -1,6 +1,6 @@
 edp-install:
 ## edp-install configuration
-## Full list of parameters are available in https://github.com/epam/edp-install/blob/v3.14.1/deploy-templates/values.yaml and in each of subchart
+## A complete list of parameters can be found in the values.yaml file at https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml, as well as in each subchart.
   global:
      # -- platform type that can be "kubernetes" or "openshift"
     platform: "kubernetes"
@@ -181,37 +181,6 @@ edp-install:
     #     visible: true
     #     icon: icon_in_base64
 
-  edp-headlamp:
-    enabled: false
-    config:
-      # -- base url path at which headlamp should run
-      baseURL: ""
-      # -- Ensure that the specified client is associated with cluster OIDC integration.
-      # -- For detailed instructions, refer to: https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks, https://docs.kuberocketci.io/docs/operator-guide/auth/ui-portal-oidc
-      oidc:
-        # Enable OIDC integration. Default: false
-        enabled: false
-        # -- OIDC Issuer URL for authentication.
-        # -- This URL identifies the OpenID Connect provider endpoint. Examples:
-        # -- Keycloak: https://keycloak.example.com/auth/realms/<realm-name>
-        # -- Azure Entra: https://sts.windows.net/<tenant-id>/
-        issuerUrl: ""
-        # -- OIDC client ID
-        clientID: "shared"
-        # -- OIDC client secret name
-        clientSecretName: "keycloak-client-headlamp-secret"
-        # -- OIDC client secret key
-        clientSecretKey: "clientSecret"
-        # -- OIDC scopes to be used
-        scopes: ""
-    # image:
-    #   repository: epamedp/edp-headlamp
-    #   tag:
-    # -- Optional array of imagePullSecrets containing private registry credentials
-    ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry
-    # imagePullSecrets: []
-    # - name: regcred
-
   edp-tekton:
     enabled: true
     # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
@@ -261,6 +230,8 @@ edp-install:
       tailLines: 100
       # -- Report comment strategy: 'update' edits the previous report comment of the same pull request, 'new' always creates a new comment
       commentStrategy: update
+      # -- Publish trailing log lines of failed steps in PR comments. Disabled by default to prevent secrets exposure
+      logsReporting: false
 
     # GitServers configuration section
     # GitServer creation depends on the gitProviders configuration, if gitProvider is not enabled,


### PR DESCRIPTION
Upgrade the edp-install dependency to 3.15.0 to pick up upstream changes, including removal of the deprecated edp-headlamp sub-chart and a new Tekton Reporter option to control whether failed-step log lines are published in PR comments.

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.